### PR TITLE
feat: support nested schemas in macros

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "08de61941b7919a65e36c0e34f8c1c41995469b86a39122158b75b4a68c4527d",
+  "originHash" : "9f9e621898c5b20cbbf2723bc86e0636a4e7d934d0dc068862b51e7a8d875d92",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,13 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import CompilerPluginSupport
 
 // Base dependencies needed on all platforms
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
 ]
 
 // Target dependencies needed on all platforms
@@ -36,7 +38,10 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "MCP",
-            targets: ["MCP"])
+            targets: ["MCP"]),
+        .library(
+            name: "MCPToolMacrosPlugin",
+            targets: ["MCPToolMacrosPlugin"])
     ],
     dependencies: dependencies,
     targets: [
@@ -45,8 +50,27 @@ let package = Package(
         .target(
             name: "MCP",
             dependencies: targetDependencies),
+        .macro(
+            name: "MCPToolMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+        .target(
+            name: "MCPToolMacrosPlugin",
+            dependencies: ["MCP", "MCPToolMacros"]
+        ),
         .testTarget(
             name: "MCPTests",
             dependencies: ["MCP"] + targetDependencies),
+        .testTarget(
+            name: "MCPToolMacrosTests",
+            dependencies: [
+                "MCPToolMacros",
+                "MCPToolMacrosPlugin",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+            ]
+        ),
     ]
 )

--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -262,3 +262,35 @@ public enum CallTool: Method {
 public struct ToolListChangedNotification: Notification {
     public static let name: String = "notifications/tools/list_changed"
 }
+
+// MARK: - Type-Safe Parameter Parsing
+
+/// Protocol for types that can be parsed from MCP tool arguments
+/// This is typically implemented by structs decorated with @ToolRegistration, @Schema, etc.
+public protocol MCPParameterParsable {
+    /// Parse tool arguments into a strongly-typed instance
+    static func parseArguments(_ args: [String: Value]) -> Self?
+}
+
+extension CallTool.Parameters {
+    /// Parse tool parameters as a strongly-typed struct
+    /// This provides type-safe parameter extraction instead of manual string-based parsing
+    ///
+    /// Usage:
+    /// ```swift
+    /// @Schema
+    /// struct FormatTemplateInput {
+    ///     @Field(description: "Format type", validOptions: ["commit", "pr-title"])  
+    ///     let formatType: String
+    /// }
+    ///
+    /// // In your tool handler:
+    /// guard let input = params.parseAs(FormatTemplateInput.self) else {
+    ///     return .init(content: [.text("Invalid parameters")], isError: true)
+    /// }
+    /// // Now you can use input.formatType directly
+    /// ```
+    public func parseAs<T>(_ type: T.Type) -> T? where T: MCPParameterParsable {
+        return T.parseArguments(self.arguments ?? [:])
+    }
+}

--- a/Sources/MCPToolMacros/Plugin.swift
+++ b/Sources/MCPToolMacros/Plugin.swift
@@ -4,9 +4,6 @@ import SwiftSyntaxMacros
 @main
 struct MCPToolMacrosPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        SchemaFieldMacro.self,
-        InputSchemaMacro.self,
-        OutputSchemaMacro.self,
         SchemaMacro.self,
         FieldMacro.self,
     ]

--- a/Sources/MCPToolMacros/Plugin.swift
+++ b/Sources/MCPToolMacros/Plugin.swift
@@ -1,0 +1,13 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MCPToolMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        SchemaFieldMacro.self,
+        InputSchemaMacro.self,
+        OutputSchemaMacro.self,
+        SchemaMacro.self,
+        FieldMacro.self,
+    ]
+}

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -88,22 +88,28 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
 }
 
 
-private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo]) -> String {
-    return properties.map { property in
-        let jsonSchemaType = swiftTypeToJsonSchemaType(property.type)
-        var schemaComponents: [String] = ["\"type\": .string(\"\(jsonSchemaType)\")"]
-        
-        if let description = property.description {
-            schemaComponents.append("\"description\": .string(\"\(description)\")")
+private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo], in root: Syntax) throws -> String {
+    return try properties.map { property in
+        let baseType = property.type.replacingOccurrences(of: "?", with: "")
+        if let jsonSchemaType = swiftTypeToJsonSchemaType(baseType) {
+            var schemaComponents: [String] = ["\"type\": .string(\"\(jsonSchemaType)\")"]
+
+            if let description = property.description {
+                schemaComponents.append("\"description\": .string(\"\(description)\")")
+            }
+
+            if let enumValues = property.enumValues, !enumValues.isEmpty {
+                let enumValuesString = enumValues.map { ".string(\"\($0)\")" }.joined(separator: ", ")
+                schemaComponents.append("\"enum\": .array([\(enumValuesString)])")
+            }
+
+            let schemaString = schemaComponents.joined(separator: ", ")
+            return "                            \"\(property.name)\": .object([\(schemaString)])"
+        } else if isSchemaAnnotatedType(baseType, in: root) {
+            return "                            \"\(property.name)\": \(baseType).inputSchema"
+        } else {
+            throw MacroError.unsupportedType("Unsupported type \(property.type) for property \(property.name)")
         }
-        
-        if let enumValues = property.enumValues, !enumValues.isEmpty {
-            let enumValuesString = enumValues.map { ".string(\"\($0)\")" }.joined(separator: ", ")
-            schemaComponents.append("\"enum\": .array([\(enumValuesString)])")
-        }
-        
-        let schemaString = schemaComponents.joined(separator: ", ")
-        return "                            \"\(property.name)\": .object([\(schemaString)])"
     }.joined(separator: ",\n")
 }
 
@@ -114,7 +120,7 @@ private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> Strin
 
 
 
-private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String {
+private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
     switch swiftType {
     case "String":
         return "string"
@@ -125,9 +131,40 @@ private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String {
     case "Bool":
         return "boolean"
     default:
-        // Default to string for unknown types
-        return "string"
+        return nil
     }
+}
+
+private func isSchemaAnnotatedType(_ typeName: String, in root: Syntax) -> Bool {
+    class Finder: SyntaxVisitor {
+        let typeName: String
+        var found = false
+
+        init(typeName: String) {
+            self.typeName = typeName
+            super.init(viewMode: .all)
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            if node.name.text == typeName {
+                if let attrs = node.attributes {
+                    for attr in attrs {
+                        if let attr = attr.as(AttributeSyntax.self),
+                           let id = attr.attributeName.as(IdentifierTypeSyntax.self),
+                           id.name.text == "Schema" {
+                            found = true
+                            return .skipChildren
+                        }
+                    }
+                }
+            }
+            return .visitChildren
+        }
+    }
+
+    let finder = Finder(typeName: typeName)
+    finder.walk(root)
+    return finder.found
 }
 
 
@@ -146,16 +183,31 @@ public struct SchemaMacro: ExtensionMacro {
         }
         
         let properties = extractSchemaFields(from: structDecl)
-        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
+        var root: Syntax = Syntax(structDecl)
+        while let parent = root.parent { root = parent }
+
+        let schemaProperties = try generateAdvancedSchemaProperties(from: properties, in: root)
         let requiredFields = generateRequiredFields(from: properties)
-        
-        let propertyExtractions = properties.map { property in
+
+        let propertyExtractions = try properties.map { property in
             let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
             if property.isOptional {
                 let baseType = property.type.replacingOccurrences(of: "?", with: "")
-                return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+                if swiftTypeToJsonSchemaType(baseType) != nil {
+                    return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+                } else if isSchemaAnnotatedType(baseType, in: root) {
+                    return "let \(varName) = args[\"\(property.name)\"].flatMap { \(baseType).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
+                } else {
+                    throw MacroError.unsupportedType("Unsupported type \(property.type) for property \(property.name)")
+                }
             } else {
-                return "let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
+                if swiftTypeToJsonSchemaType(property.type) != nil {
+                    return "let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
+                } else if isSchemaAnnotatedType(property.type, in: root) {
+                    return "let \(varName) = \(property.type).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())"
+                } else {
+                    throw MacroError.unsupportedType("Unsupported type \(property.type) for property \(property.name)")
+                }
             }
         }.joined(separator: ",\n                    ")
         
@@ -210,6 +262,7 @@ public struct FieldMacro: PeerMacro {
 enum MacroError: Error, CustomStringConvertible {
     case invalidDeclaration(String)
     case missingArguments(String)
+    case unsupportedType(String)
     
     var description: String {
         switch self {
@@ -217,6 +270,8 @@ enum MacroError: Error, CustomStringConvertible {
             return "Invalid declaration: \(message)"
         case .missingArguments(let message):
             return "Missing arguments: \(message)"
+        case .unsupportedType(let message):
+            return "Unsupported type: \(message)"
         }
     }
 }

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -1,0 +1,348 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
+
+// MARK: - Schema Field Information
+struct SchemaFieldInfo {
+    let name: String
+    let type: String
+    let description: String?
+    let enumValues: [String]?
+    let isRequired: Bool
+    let isOptional: Bool
+    
+    init(name: String, type: String, description: String? = nil, enumValues: [String]? = nil, isRequired: Bool = true) {
+        self.name = name
+        self.type = type
+        self.description = description
+        self.enumValues = enumValues
+        self.isRequired = isRequired
+        self.isOptional = type.hasSuffix("?")
+    }
+}
+
+
+// MARK: - Helper Methods
+
+private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFieldInfo] {
+    return structDecl.memberBlock.members.compactMap { member -> SchemaFieldInfo? in
+        guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+              let typeAnnotation = binding.typeAnnotation else {
+            return nil
+        }
+        
+        let propertyName = pattern.identifier.text
+        let propertyType = typeAnnotation.type.trimmed.description
+        
+        // Extract Field attributes if present
+        var description: String?
+        var enumValues: [String]?
+        var isRequired = !propertyType.hasSuffix("?")
+        
+        for attribute in varDecl.attributes {
+            if let attributeNode = attribute.as(AttributeSyntax.self),
+               let identifier = attributeNode.attributeName.as(IdentifierTypeSyntax.self),
+               (identifier.name.text == "SchemaField" || identifier.name.text == "Field") {
+                
+                // Parse SchemaField or Field arguments
+                if let arguments = attributeNode.arguments?.as(LabeledExprListSyntax.self) {
+                    for argument in arguments {
+                        switch argument.label?.text {
+                        case "description":
+                            if let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self),
+                               let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                                description = segment.content.text
+                            }
+                        case "validOptions", "enum":
+                            if let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
+                                enumValues = arrayExpr.elements.compactMap { element in
+                                    if let stringLiteral = element.expression.as(StringLiteralExprSyntax.self),
+                                       let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                                        return segment.content.text
+                                    }
+                                    return nil
+                                }
+                            }
+                        case "isRequired":
+                            if let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
+                                isRequired = boolLiteral.literal.text == "true"
+                            }
+                        default:
+                            break
+                        }
+                    }
+                }
+            }
+        }
+        
+        return SchemaFieldInfo(
+            name: propertyName,
+            type: propertyType,
+            description: description,
+            enumValues: enumValues,
+            isRequired: isRequired
+        )
+    }
+}
+
+
+private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo]) -> String {
+    return properties.map { property in
+        let jsonSchemaType = swiftTypeToJsonSchemaType(property.type)
+        var schemaComponents: [String] = ["\"type\": .string(\"\(jsonSchemaType)\")"]
+        
+        if let description = property.description {
+            schemaComponents.append("\"description\": .string(\"\(description)\")")
+        }
+        
+        if let enumValues = property.enumValues, !enumValues.isEmpty {
+            let enumValuesString = enumValues.map { ".string(\"\($0)\")" }.joined(separator: ", ")
+            schemaComponents.append("\"enum\": .array([\(enumValuesString)])")
+        }
+        
+        let schemaString = schemaComponents.joined(separator: ", ")
+        return "                            \"\(property.name)\": .object([\(schemaString)])"
+    }.joined(separator: ",\n")
+}
+
+private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> String {
+    let requiredFields = properties.filter { $0.isRequired }.map { ".string(\"\($0.name)\")" }
+    return requiredFields.joined(separator: ", ")
+}
+
+
+private func generateParseArgumentsBody(structName: String, properties: [SchemaFieldInfo]) -> String {
+    let propertyExtractions = properties.map { property in
+        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+        if property.isOptional {
+            let baseType = property.type.replacingOccurrences(of: "?", with: "")
+            return "                    let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+        } else {
+            return "                    let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
+        }
+    }.joined(separator: ",\n")
+    
+    let propertyList = properties.map { property in
+        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+        return "\(property.name): \(varName)"
+    }.joined(separator: ", ")
+    
+    return "                guard\n\(propertyExtractions)\n                else { \n                    return nil \n                }\n                \n                return \(structName)(\(propertyList))"
+}
+
+private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String {
+    switch swiftType {
+    case "String":
+        return "string"
+    case "Int":
+        return "integer"
+    case "Double", "Float":
+        return "number"
+    case "Bool":
+        return "boolean"
+    default:
+        // Default to string for unknown types
+        return "string"
+    }
+}
+
+// MARK: - SchemaField Macro
+
+public struct SchemaFieldMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // SchemaField is primarily used as an annotation for ToolRegistrationMacro
+        // It doesn't generate additional code itself
+        return []
+    }
+}
+
+// MARK: - InputSchema Macro
+
+public struct InputSchemaMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            throw MacroError.invalidDeclaration("@InputSchema can only be applied to structs")
+        }
+        
+        let properties = extractSchemaFields(from: structDecl)
+        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
+        let requiredFields = generateRequiredFields(from: properties)
+        
+        let propertyExtractions = properties.map { property in
+            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+            if property.isOptional {
+                let baseType = property.type.replacingOccurrences(of: "?", with: "")
+                return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+            } else {
+                return "let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
+            }
+        }.joined(separator: ",\n                    ")
+        
+        let propertyList = properties.map { property in
+            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+            return "\(property.name): \(varName)"
+        }.joined(separator: ", ")
+        
+        let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
+        extension \(type): MCP.MCPParameterParsable {
+            public static var inputSchema: MCP.Value {
+                .object([
+                    "type": .string("object"),
+                    "properties": .object([
+        \(raw: schemaProperties)
+                    ])\(raw: requiredFields.isEmpty ? "" : ",\n                    \"required\": .array([\(requiredFields)])")
+                ])
+            }
+            
+            public static func parseArguments(_ args: [String: MCP.Value]) -> \(type)? {
+                guard
+                    \(raw: propertyExtractions)
+                else { 
+                    return nil 
+                }
+                
+                return \(type)(\(raw: propertyList))
+            }
+        }
+        """)
+        
+        return [extensionDecl]
+    }
+}
+
+// MARK: - OutputSchema Macro
+
+public struct OutputSchemaMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            throw MacroError.invalidDeclaration("@OutputSchema can only be applied to structs")
+        }
+        
+        let properties = extractSchemaFields(from: structDecl)
+        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
+        let requiredFields = generateRequiredFields(from: properties)
+        
+        let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
+        extension \(type) {
+            public static var outputSchema: MCP.Value {
+                .object([
+                    "type": .string("object"),
+                    "properties": .object([
+        \(raw: schemaProperties)
+                    ])\(raw: requiredFields.isEmpty ? "" : ",\n                    \"required\": .array([\(requiredFields)])")
+                ])
+            }
+        }
+        """)
+        
+        return [extensionDecl]
+    }
+}
+
+// MARK: - Schema Macro (Simpler API)
+
+public struct SchemaMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            throw MacroError.invalidDeclaration("@Schema can only be applied to structs")
+        }
+        
+        let properties = extractSchemaFields(from: structDecl)
+        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
+        let requiredFields = generateRequiredFields(from: properties)
+        
+        let propertyExtractions = properties.map { property in
+            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+            if property.isOptional {
+                let baseType = property.type.replacingOccurrences(of: "?", with: "")
+                return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+            } else {
+                return "let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
+            }
+        }.joined(separator: ",\n                    ")
+        
+        let propertyList = properties.map { property in
+            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+            return "\(property.name): \(varName)"
+        }.joined(separator: ", ")
+        
+        let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
+        extension \(type): MCP.MCPParameterParsable {
+            public static var inputSchema: MCP.Value {
+                .object([
+                    "type": .string("object"),
+                    "properties": .object([
+        \(raw: schemaProperties)
+                    ])\(raw: requiredFields.isEmpty ? "" : ",\n                    \"required\": .array([\(requiredFields)])")
+                ])
+            }
+            
+            public static func parseArguments(_ args: [String: MCP.Value]) -> \(type)? {
+                guard
+                    \(raw: propertyExtractions)
+                else { 
+                    return nil 
+                }
+                
+                return \(type)(\(raw: propertyList))
+            }
+        }
+        """)
+        
+        return [extensionDecl]
+    }
+}
+
+// MARK: - Field Macro (Simpler API)
+
+public struct FieldMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // Field is primarily used as an annotation for @Schema
+        // It doesn't generate additional code itself
+        return []
+    }
+}
+
+// MARK: - Error Types
+
+enum MacroError: Error, CustomStringConvertible {
+    case invalidDeclaration(String)
+    case missingArguments(String)
+    
+    var description: String {
+        switch self {
+        case .invalidDeclaration(let message):
+            return "Invalid declaration: \(message)"
+        case .missingArguments(let message):
+            return "Missing arguments: \(message)"
+        }
+    }
+}

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -113,24 +113,6 @@ private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> Strin
 }
 
 
-private func generateParseArgumentsBody(structName: String, properties: [SchemaFieldInfo]) -> String {
-    let propertyExtractions = properties.map { property in
-        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-        if property.isOptional {
-            let baseType = property.type.replacingOccurrences(of: "?", with: "")
-            return "                    let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
-        } else {
-            return "                    let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
-        }
-    }.joined(separator: ",\n")
-    
-    let propertyList = properties.map { property in
-        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-        return "\(property.name): \(varName)"
-    }.joined(separator: ", ")
-    
-    return "                guard\n\(propertyExtractions)\n                else { \n                    return nil \n                }\n                \n                return \(structName)(\(propertyList))"
-}
 
 private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String {
     switch swiftType {
@@ -148,114 +130,6 @@ private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String {
     }
 }
 
-// MARK: - SchemaField Macro
-
-public struct SchemaFieldMacro: PeerMacro {
-    public static func expansion(
-        of node: AttributeSyntax,
-        providingPeersOf declaration: some DeclSyntaxProtocol,
-        in context: some MacroExpansionContext
-    ) throws -> [DeclSyntax] {
-        // SchemaField is primarily used as an annotation for ToolRegistrationMacro
-        // It doesn't generate additional code itself
-        return []
-    }
-}
-
-// MARK: - InputSchema Macro
-
-public struct InputSchemaMacro: ExtensionMacro {
-    public static func expansion(
-        of node: AttributeSyntax,
-        attachedTo declaration: some DeclGroupSyntax,
-        providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo protocols: [TypeSyntax],
-        in context: some MacroExpansionContext
-    ) throws -> [ExtensionDeclSyntax] {
-        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
-            throw MacroError.invalidDeclaration("@InputSchema can only be applied to structs")
-        }
-        
-        let properties = extractSchemaFields(from: structDecl)
-        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
-        let requiredFields = generateRequiredFields(from: properties)
-        
-        let propertyExtractions = properties.map { property in
-            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-            if property.isOptional {
-                let baseType = property.type.replacingOccurrences(of: "?", with: "")
-                return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
-            } else {
-                return "let \(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)"
-            }
-        }.joined(separator: ",\n                    ")
-        
-        let propertyList = properties.map { property in
-            let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-            return "\(property.name): \(varName)"
-        }.joined(separator: ", ")
-        
-        let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
-        extension \(type): MCP.MCPParameterParsable {
-            public static var inputSchema: MCP.Value {
-                .object([
-                    "type": .string("object"),
-                    "properties": .object([
-        \(raw: schemaProperties)
-                    ])\(raw: requiredFields.isEmpty ? "" : ",\n                    \"required\": .array([\(requiredFields)])")
-                ])
-            }
-            
-            public static func parseArguments(_ args: [String: MCP.Value]) -> \(type)? {
-                guard
-                    \(raw: propertyExtractions)
-                else { 
-                    return nil 
-                }
-                
-                return \(type)(\(raw: propertyList))
-            }
-        }
-        """)
-        
-        return [extensionDecl]
-    }
-}
-
-// MARK: - OutputSchema Macro
-
-public struct OutputSchemaMacro: ExtensionMacro {
-    public static func expansion(
-        of node: AttributeSyntax,
-        attachedTo declaration: some DeclGroupSyntax,
-        providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo protocols: [TypeSyntax],
-        in context: some MacroExpansionContext
-    ) throws -> [ExtensionDeclSyntax] {
-        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
-            throw MacroError.invalidDeclaration("@OutputSchema can only be applied to structs")
-        }
-        
-        let properties = extractSchemaFields(from: structDecl)
-        let schemaProperties = generateAdvancedSchemaProperties(from: properties)
-        let requiredFields = generateRequiredFields(from: properties)
-        
-        let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
-        extension \(type) {
-            public static var outputSchema: MCP.Value {
-                .object([
-                    "type": .string("object"),
-                    "properties": .object([
-        \(raw: schemaProperties)
-                    ])\(raw: requiredFields.isEmpty ? "" : ",\n                    \"required\": .array([\(requiredFields)])")
-                ])
-            }
-        }
-        """)
-        
-        return [extensionDecl]
-    }
-}
 
 // MARK: - Schema Macro (Simpler API)
 

--- a/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
+++ b/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
@@ -1,0 +1,7 @@
+// Re-export the macro definition and related utilities
+@_exported import MCP
+
+// MARK: - SchemaProviding Protocol
+public protocol SchemaProviding {
+    static var inputSchema: MCP.Value { get }
+}

--- a/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
+++ b/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A macro that adds schema information to struct properties.
+/// 
+/// This macro is used in conjunction with @InputSchema, @OutputSchema, or @Schema
+/// to provide additional metadata for JSON schema generation.
+///
+/// Usage:
+/// ```swift
+/// @SchemaField(description: "The temperature units to use", enum: ["celsius", "fahrenheit"])
+/// let units: String
+/// ```
+@attached(peer)
+public macro SchemaField(
+    description: String? = nil,
+    enum: [String]? = nil
+) = #externalMacro(
+    module: "MCPToolMacros",
+    type: "SchemaFieldMacro"
+)
+
+/// A macro that generates input schema for a Swift struct.
+/// 
+/// This macro generates a static `inputSchema` property containing the JSON schema
+/// definition for the struct, suitable for use in MCP tool definitions.
+///
+/// Usage:
+/// ```swift
+/// @InputSchema
+/// struct FormatTemplateInput {
+///     @SchemaField(description: "The type of format template", enum: ["commit", "pr-title"])
+///     let formatType: String
+/// }
+/// ```
+@attached(extension, conformances: MCP.MCPParameterParsable, names: named(inputSchema), named(parseArguments))
+public macro InputSchema() = #externalMacro(
+    module: "MCPToolMacros",
+    type: "InputSchemaMacro"
+)
+
+/// A macro that generates output schema for a Swift struct.
+/// 
+/// This macro generates a static `outputSchema` property containing the JSON schema
+/// definition for the struct, suitable for documenting tool output format.
+///
+/// Usage:
+/// ```swift
+/// @OutputSchema
+/// struct FormatTemplateOutput {
+///     let template: String
+///     let variables: [String]?
+/// }
+/// ```
+@attached(extension, names: named(outputSchema))
+public macro OutputSchema() = #externalMacro(
+    module: "MCPToolMacros",
+    type: "OutputSchemaMacro"
+)
+
+/// A macro that generates input schema for a Swift struct (simpler API).
+/// 
+/// This macro generates a static `inputSchema` property containing the JSON schema
+/// definition for the struct. This is the simpler alternative to @InputSchema.
+///
+/// Usage:
+/// ```swift
+/// @Schema
+/// struct FormatTemplateInput {
+///     @Field(description: "The type of format template", validOptions: ["commit", "pr-title"])
+///     let formatType: String
+/// }
+/// ```
+@attached(extension, conformances: MCP.MCPParameterParsable, names: named(inputSchema), named(parseArguments))
+public macro Schema() = #externalMacro(
+    module: "MCPToolMacros",
+    type: "SchemaMacro"
+)
+
+/// A macro that adds schema information to struct properties (simpler API).
+/// 
+/// This macro is used in conjunction with @Schema to provide metadata
+/// for JSON schema generation. This is the simpler alternative to @SchemaField.
+///
+/// Usage:
+/// ```swift
+/// @Field(description: "The temperature units to use", validOptions: ["celsius", "fahrenheit"], isRequired: true)
+/// var units: String
+/// ```
+@attached(peer)
+public macro Field(
+    description: String? = nil,
+    validOptions: [String]? = nil,
+    isRequired: Bool = true
+) = #externalMacro(
+    module: "MCPToolMacros",
+    type: "FieldMacro"
+)
+

--- a/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
+++ b/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
@@ -1,66 +1,9 @@
 import Foundation
 
-/// A macro that adds schema information to struct properties.
-/// 
-/// This macro is used in conjunction with @InputSchema, @OutputSchema, or @Schema
-/// to provide additional metadata for JSON schema generation.
-///
-/// Usage:
-/// ```swift
-/// @SchemaField(description: "The temperature units to use", enum: ["celsius", "fahrenheit"])
-/// let units: String
-/// ```
-@attached(peer)
-public macro SchemaField(
-    description: String? = nil,
-    enum: [String]? = nil
-) = #externalMacro(
-    module: "MCPToolMacros",
-    type: "SchemaFieldMacro"
-)
-
 /// A macro that generates input schema for a Swift struct.
 /// 
 /// This macro generates a static `inputSchema` property containing the JSON schema
 /// definition for the struct, suitable for use in MCP tool definitions.
-///
-/// Usage:
-/// ```swift
-/// @InputSchema
-/// struct FormatTemplateInput {
-///     @SchemaField(description: "The type of format template", enum: ["commit", "pr-title"])
-///     let formatType: String
-/// }
-/// ```
-@attached(extension, conformances: MCP.MCPParameterParsable, names: named(inputSchema), named(parseArguments))
-public macro InputSchema() = #externalMacro(
-    module: "MCPToolMacros",
-    type: "InputSchemaMacro"
-)
-
-/// A macro that generates output schema for a Swift struct.
-/// 
-/// This macro generates a static `outputSchema` property containing the JSON schema
-/// definition for the struct, suitable for documenting tool output format.
-///
-/// Usage:
-/// ```swift
-/// @OutputSchema
-/// struct FormatTemplateOutput {
-///     let template: String
-///     let variables: [String]?
-/// }
-/// ```
-@attached(extension, names: named(outputSchema))
-public macro OutputSchema() = #externalMacro(
-    module: "MCPToolMacros",
-    type: "OutputSchemaMacro"
-)
-
-/// A macro that generates input schema for a Swift struct (simpler API).
-/// 
-/// This macro generates a static `inputSchema` property containing the JSON schema
-/// definition for the struct. This is the simpler alternative to @InputSchema.
 ///
 /// Usage:
 /// ```swift
@@ -76,10 +19,10 @@ public macro Schema() = #externalMacro(
     type: "SchemaMacro"
 )
 
-/// A macro that adds schema information to struct properties (simpler API).
+/// A macro that adds schema information to struct properties.
 /// 
 /// This macro is used in conjunction with @Schema to provide metadata
-/// for JSON schema generation. This is the simpler alternative to @SchemaField.
+/// for JSON schema generation.
 ///
 /// Usage:
 /// ```swift

--- a/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
+++ b/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
@@ -18,38 +18,36 @@ final class SchemaMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            struct UserPreferences {
-                @Field(description: "User's preferred theme", validOptions: ["light", "dark"])
-                let theme: String
-                
-                @Field(description: "Enable notifications")
-                let notifications: Bool
-            }
-            
-            extension UserPreferences: MCP.MCPParameterParsable {
-                public static var inputSchema: MCP.Value {
-                    .object([
-                        "type": .string("object"),
-                        "properties": .object([
+struct UserPreferences {
+    let theme: String
+    
+    let notifications: Bool
+}
+
+extension UserPreferences: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
                             "theme": .object(["type": .string("string"), "description": .string("User's preferred theme"), "enum": .array([.string("light"), .string("dark")])]),
                             "notifications": .object(["type": .string("boolean"), "description": .string("Enable notifications")])
-                        ]),
-                        "required": .array([.string("theme"), .string("notifications")])
-                    ])
-                }
-                
-                public static func parseArguments(_ args: [String: MCP.Value]) -> UserPreferences? {
-                    guard
-                        let theme = String(args["theme"] ?? .null),
-                        let notifications = Bool(args["notifications"] ?? .null)
-                    else { 
-                        return nil 
-                    }
-                    
-                    return UserPreferences(theme: theme, notifications: notifications)
-                }
-            }
-            """,
+            ]),
+                    "required": .array([.string("theme"), .string("notifications")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> UserPreferences? {
+        guard
+            let parsedTheme = String(args["theme"] ?? .null),
+                    let parsedNotifications = Bool(args["notifications"] ?? .null)
+        else {
+            return nil
+        }
+
+        return UserPreferences(theme: parsedTheme, notifications: parsedNotifications)
+    }
+}
+""",
             macros: [
                 "Schema": SchemaMacro.self,
                 "Field": FieldMacro.self
@@ -57,80 +55,52 @@ final class SchemaMacroTests: XCTestCase {
         )
     }
     
-    func testInputSchemaMacro() throws {
+    func testSchemaMacroWithOptionalField() throws {
         assertMacroExpansion(
             """
-            @InputSchema
-            struct UserInput {
-                @SchemaField(description: "User name")
+            @Schema
+            struct UserProfile {
+                @Field(description: "User name")
                 let name: String
-            }
-            """,
-            expandedSource: """
-            struct UserInput {
-                @SchemaField(description: "User name")
-                let name: String
-            }
-            
-            extension UserInput: MCP.MCPParameterParsable {
-                public static var inputSchema: MCP.Value {
-                    .object([
-                        "type": .string("object"),
-                        "properties": .object([
-                            "name": .object(["type": .string("string"), "description": .string("User name")])
-                        ]),
-                        "required": .array([.string("name")])
-                    ])
-                }
                 
-                public static func parseArguments(_ args: [String: MCP.Value]) -> UserInput? {
-                    guard
-                        let name = String(args["name"] ?? .null)
-                    else { 
-                        return nil 
-                    }
-                    
-                    return UserInput(name: name)
-                }
-            }
-            """,
-            macros: [
-                "InputSchema": InputSchemaMacro.self,
-                "SchemaField": SchemaFieldMacro.self
-            ]
-        )
-    }
-    
-    func testOutputSchemaMacro() throws {
-        assertMacroExpansion(
-            """
-            @OutputSchema
-            struct UserOutput {
-                @SchemaField(description: "User response")
-                let response: String
+                @Field(description: "User email")
+                let email: String?
             }
             """,
             expandedSource: """
-            struct UserOutput {
-                @SchemaField(description: "User response")
-                let response: String
-            }
-            
-            extension UserOutput {
-                public static var outputSchema: MCP.Value {
-                    .object([
-                        "type": .string("object"),
-                        "properties": .object([
-                            "response": .object(["type": .string("string"), "description": .string("User response")])
-                        ]),
-                        "required": .array([.string("response")])
-                    ])
-                }
-            }
-            """,
+struct UserProfile {
+    let name: String
+    
+    let email: String?
+}
+
+extension UserProfile: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "name": .object(["type": .string("string"), "description": .string("User name")]),
+                            "email": .object(["type": .string("string"), "description": .string("User email")])
+            ]),
+                    "required": .array([.string("name")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> UserProfile? {
+        guard
+            let parsedName = String(args["name"] ?? .null),
+                    let parsedEmail = String(args["email"] ?? .null)
+        else {
+            return nil
+        }
+
+        return UserProfile(name: parsedName, email: parsedEmail)
+    }
+}
+""",
             macros: [
-                "OutputSchema": OutputSchemaMacro.self,
-                "SchemaField": SchemaFieldMacro.self
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
             ]
         )
     }

--- a/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
+++ b/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
@@ -104,4 +104,79 @@ extension UserProfile: MCP.MCPParameterParsable {
             ]
         )
     }
+
+    func testSchemaMacroWithNestedSchema() throws {
+        assertMacroExpansion(
+            """
+            @Schema
+            struct Address {
+                @Field(description: "Street")
+                let street: String
+            }
+
+            @Schema
+            struct User {
+                @Field(description: "User address")
+                let address: Address
+            }
+            """,
+            expandedSource: """
+struct Address {
+    let street: String
+}
+
+extension Address: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "street": .object(["type": .string("string"), "description": .string("Street")])
+            ]),
+                    "required": .array([.string("street")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> Address? {
+        guard
+            let parsedStreet = String(args["street"] ?? .null)
+        else {
+            return nil
+        }
+
+        return Address(street: parsedStreet)
+    }
+}
+
+struct User {
+    let address: Address
+}
+
+extension User: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "address": Address.inputSchema
+            ]),
+                    "required": .array([.string("address")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> User? {
+        guard
+            let parsedAddress = Address.parseArguments(args["address"]?.objectValue ?? Dictionary<String, MCP.Value>())
+        else {
+            return nil
+        }
+
+        return User(address: parsedAddress)
+    }
+}
+""",
+            macros: [
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
+            ]
+        )
+    }
 }

--- a/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
+++ b/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import SwiftSyntaxMacrosTestSupport
+
+@testable import MCPToolMacros
+
+final class SchemaMacroTests: XCTestCase {
+    
+    func testSchemaMacroWithField() throws {
+        assertMacroExpansion(
+            """
+            @Schema
+            struct UserPreferences {
+                @Field(description: "User's preferred theme", validOptions: ["light", "dark"])
+                let theme: String
+                
+                @Field(description: "Enable notifications")
+                let notifications: Bool
+            }
+            """,
+            expandedSource: """
+            struct UserPreferences {
+                @Field(description: "User's preferred theme", validOptions: ["light", "dark"])
+                let theme: String
+                
+                @Field(description: "Enable notifications")
+                let notifications: Bool
+            }
+            
+            extension UserPreferences: MCP.MCPParameterParsable {
+                public static var inputSchema: MCP.Value {
+                    .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "theme": .object(["type": .string("string"), "description": .string("User's preferred theme"), "enum": .array([.string("light"), .string("dark")])]),
+                            "notifications": .object(["type": .string("boolean"), "description": .string("Enable notifications")])
+                        ]),
+                        "required": .array([.string("theme"), .string("notifications")])
+                    ])
+                }
+                
+                public static func parseArguments(_ args: [String: MCP.Value]) -> UserPreferences? {
+                    guard
+                        let theme = String(args["theme"] ?? .null),
+                        let notifications = Bool(args["notifications"] ?? .null)
+                    else { 
+                        return nil 
+                    }
+                    
+                    return UserPreferences(theme: theme, notifications: notifications)
+                }
+            }
+            """,
+            macros: [
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
+            ]
+        )
+    }
+    
+    func testInputSchemaMacro() throws {
+        assertMacroExpansion(
+            """
+            @InputSchema
+            struct UserInput {
+                @SchemaField(description: "User name")
+                let name: String
+            }
+            """,
+            expandedSource: """
+            struct UserInput {
+                @SchemaField(description: "User name")
+                let name: String
+            }
+            
+            extension UserInput: MCP.MCPParameterParsable {
+                public static var inputSchema: MCP.Value {
+                    .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "name": .object(["type": .string("string"), "description": .string("User name")])
+                        ]),
+                        "required": .array([.string("name")])
+                    ])
+                }
+                
+                public static func parseArguments(_ args: [String: MCP.Value]) -> UserInput? {
+                    guard
+                        let name = String(args["name"] ?? .null)
+                    else { 
+                        return nil 
+                    }
+                    
+                    return UserInput(name: name)
+                }
+            }
+            """,
+            macros: [
+                "InputSchema": InputSchemaMacro.self,
+                "SchemaField": SchemaFieldMacro.self
+            ]
+        )
+    }
+    
+    func testOutputSchemaMacro() throws {
+        assertMacroExpansion(
+            """
+            @OutputSchema
+            struct UserOutput {
+                @SchemaField(description: "User response")
+                let response: String
+            }
+            """,
+            expandedSource: """
+            struct UserOutput {
+                @SchemaField(description: "User response")
+                let response: String
+            }
+            
+            extension UserOutput {
+                public static var outputSchema: MCP.Value {
+                    .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "response": .object(["type": .string("string"), "description": .string("User response")])
+                        ]),
+                        "required": .array([.string("response")])
+                    ])
+                }
+            }
+            """,
+            macros: [
+                "OutputSchema": OutputSchemaMacro.self,
+                "SchemaField": SchemaFieldMacro.self
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- expand Schema macro to recursively process nested @Schema types
- surface an error when encountering unsupported property types
- add regression test for nested schema handling

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-syntax.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68967271f24c8332828594a9f877a38c