### PR TITLE
feat: add @Schema and @Field macros for MCP tool parameter JSON Schema and type-safe parsing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "08de61941b7919a65e36c0e34f8c1c41995469b86a39122158b75b4a68c4527d",
+  "originHash" : "ed2c6b3577fe15b31a13273a1502145e7050f87dd688213e03c183b6fe58c36a",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loopwork-ai/eventsource.git",
+      "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "e83f076811f32757305b8bf69ac92d05626ffdd7",
-        "version" : "1.1.0"
+        "revision" : "07957602bb99a5355c810187e66e6ce378a1057d",
+        "version" : "1.1.1"
       }
     },
     {
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,20 +1,24 @@
 // swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import PackageDescription
 
 // Base dependencies needed on all platforms
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
-    .package(url: "https://github.com/mattt/eventsource.git", from: "1.1.0")
+    .package(url: "https://github.com/mattt/eventsource.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
 ]
 
 // Target dependencies needed on all platforms
 var targetDependencies: [Target.Dependency] = [
     .product(name: "SystemPackage", package: "swift-system"),
     .product(name: "Logging", package: "swift-log"),
-    .product(name: "EventSource", package: "eventsource", condition: .when(platforms: [.macOS, .iOS, .tvOS, .visionOS, .watchOS]))
+    .product(
+        name: "EventSource", package: "eventsource",
+        condition: .when(platforms: [.macOS, .iOS, .tvOS, .visionOS, .watchOS])),
 ]
 
 let package = Package(
@@ -31,7 +35,10 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "MCP",
-            targets: ["MCP"])
+            targets: ["MCP"]),
+        .library(
+            name: "MCPToolMacrosPlugin",
+            targets: ["MCPToolMacrosPlugin"]),
     ],
     dependencies: dependencies,
     targets: [
@@ -40,8 +47,27 @@ let package = Package(
         .target(
             name: "MCP",
             dependencies: targetDependencies),
+        .macro(
+            name: "MCPToolMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            ]
+        ),
+        .target(
+            name: "MCPToolMacrosPlugin",
+            dependencies: ["MCP", "MCPToolMacros"]
+        ),
         .testTarget(
             name: "MCPTests",
             dependencies: ["MCP"] + targetDependencies),
+        .testTarget(
+            name: "MCPToolMacrosTests",
+            dependencies: [
+                "MCPToolMacros",
+                "MCPToolMacrosPlugin",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
     ]
 )

--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -279,7 +279,7 @@ extension CallTool.Parameters {
     /// ```swift
     /// @Schema
     /// struct FormatTemplateInput {
-    ///     @Field(description: "Format type", validOptions: ["commit", "pr-title"])  
+    ///     @Field(description: "Format type", constraint: .options(["commit", "pr-title"]))  
     ///     let formatType: String
     /// }
     ///

--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -270,7 +270,6 @@ public protocol MCPParameterParsable {
     static func parseArguments(_ args: [String: Value]) -> Self?
 }
 
-
 extension CallTool.Parameters {
     /// Parse tool parameters as a strongly-typed struct
     /// This provides type-safe parameter extraction instead of manual string-based parsing

--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -260,3 +260,36 @@ public enum CallTool: Method {
 public struct ToolListChangedNotification: Notification {
     public static let name: String = "notifications/tools/list_changed"
 }
+
+// MARK: - Type-Safe Parameter Parsing
+
+/// Protocol for types that can be parsed from MCP tool arguments
+/// This is typically implemented by structs decorated with @ToolRegistration, @Schema, etc.
+public protocol MCPParameterParsable {
+    /// Parse tool arguments into a strongly-typed instance
+    static func parseArguments(_ args: [String: Value]) -> Self?
+}
+
+
+extension CallTool.Parameters {
+    /// Parse tool parameters as a strongly-typed struct
+    /// This provides type-safe parameter extraction instead of manual string-based parsing
+    ///
+    /// Usage:
+    /// ```swift
+    /// @Schema
+    /// struct FormatTemplateInput {
+    ///     @Field(description: "Format type", validOptions: ["commit", "pr-title"])  
+    ///     let formatType: String
+    /// }
+    ///
+    /// // In your tool handler:
+    /// guard let input = params.parseAs(FormatTemplateInput.self) else {
+    ///     return .init(content: [.text("Invalid parameters")], isError: true)
+    /// }
+    /// // Now you can use input.formatType directly
+    /// ```
+    public func parseAs<T>(_ type: T.Type) -> T? where T: MCPParameterParsable {
+        return T.parseArguments(self.arguments ?? [:])
+    }
+}

--- a/Sources/MCPToolMacros/Plugin.swift
+++ b/Sources/MCPToolMacros/Plugin.swift
@@ -1,0 +1,10 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MCPToolMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        SchemaMacro.self,
+        FieldMacro.self,
+    ]
+}

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -229,101 +229,165 @@ private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> Strin
     return requiredFields.joined(separator: ",\n\(SCHEMA_INDENT)")
 }
 
-// 共用的 macro 展開邏輯
-private func generateSchemaExtension(
-    for type: some TypeSyntaxProtocol,
-    from structDecl: StructDeclSyntax,
-    protocolName: String,
-    schemaPropertyName: String,
-    parseMethodName: String,
-    parseMethodSignature: String
-) throws -> ExtensionDeclSyntax {
-    let properties = extractSchemaFields(from: structDecl)
-    var root: Syntax = Syntax(structDecl)
-    while let parent = root.parent { root = parent }
+// MARK: - Property Classification
 
-    let schemaProperties = generateAdvancedSchemaProperties(from: properties, in: root)
-    let requiredFields = generateRequiredFields(from: properties)
+struct PropertyClassification {
+    let schemaFields: [SchemaFieldInfo]
+    let optionalFields: [SchemaFieldInfo]
+    let requiredFields: [SchemaFieldInfo]
+    let allProperties: [PropertyInfo]
+}
 
-    // 分離可選和必需字段的解析邏輯
-    let optionalProperties = properties.filter { $0.isOptional }
-    let requiredProperties = properties.filter { !$0.isOptional }
+private func classifyProperties(from structDecl: StructDeclSyntax) -> PropertyClassification {
+    let schemaFields = extractSchemaFields(from: structDecl)
+    let allProperties = extractAllProperties(from: structDecl)
     
-    let optionalExtractions = optionalProperties.map { property in
-        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-        let baseType = property.type.replacingOccurrences(of: "?", with: "")
-        
-        if swiftTypeToJsonSchemaType(baseType) != nil {
-            return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
-        } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
-            let elementType = String(baseType.dropFirst().dropLast())
-            return "let \(varName) = args[\"\(property.name)\"]?.arrayValue?.compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
-        } else {
-            return "let \(varName) = args[\"\(property.name)\"].flatMap { \(baseType).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
-        }
+    let optionalFields = schemaFields.filter { $0.isOptional }
+    let requiredFields = schemaFields.filter { !$0.isOptional }
+    
+    return PropertyClassification(
+        schemaFields: schemaFields,
+        optionalFields: optionalFields,
+        requiredFields: requiredFields,
+        allProperties: allProperties
+    )
+}
+
+// MARK: - Parsing Logic Generation
+
+struct ParsingLogic {
+    let optionalExtractions: [String]
+    let requiredGuardBindings: [String]
+    let requiredPostGuardLines: [String]
+    let schemaCheckLines: [String]
+    let propertyList: String
+}
+
+private func generateParsingLogic(
+    for classification: PropertyClassification
+) throws -> ParsingLogic {
+    
+    // Optional field extractions
+    let optionalExtractions = classification.optionalFields.map { property in
+        return generateOptionalExtraction(for: property)
     }
     
-    // 必填欄位：將需要 Optional 綁定的條件放入 guard，並在 guard 之後做必要的後處理（例如必填陣列的解析）
+    // Required field processing
     var requiredGuardBindings: [String] = []
     var requiredPostGuardLines: [String] = []
-    for property in requiredProperties {
-        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-        if swiftTypeToJsonSchemaType(property.type) != nil {
-            requiredGuardBindings.append("\(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)")
-        } else if property.type.hasPrefix("[") && property.type.hasSuffix("]") {
-            let elementType = String(property.type.dropFirst().dropLast())
-            let rawName = "raw\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-            requiredGuardBindings.append("\(rawName) = args[\"\(property.name)\"]?.arrayValue")
-            requiredPostGuardLines.append("let \(varName) = \(rawName).compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })")
-        } else {
-            requiredGuardBindings.append("\(varName) = \(property.type).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())")
+    
+    for property in classification.requiredFields {
+        let (guardBinding, postGuardLine) = generateRequiredFieldLogic(for: property)
+        requiredGuardBindings.append(guardBinding)
+        if let postGuard = postGuardLine {
+            requiredPostGuardLines.append(postGuard)
         }
     }
     
-    // propertyExtractions 不再需要，因為我們已經分離了可選和必需字段的處理
+    // Schema type checking
+    let schemaCheckLines = generateSchemaTypeChecks(for: classification.schemaFields)
     
-    // 提取所有屬性（包含非 @Field 的屬性）來生成完整的建構子呼叫
-    let allProperties = extractAllProperties(from: structDecl)
-    let propertyList = try allProperties.compactMap { propertyInfo -> String? in
-        if let fieldProperty = properties.first(where: { $0.name == propertyInfo.name }) {
-            // 這是 @Field 屬性，使用解析出的值
-            let varName = "parsed\(fieldProperty.name.prefix(1).uppercased())\(fieldProperty.name.dropFirst())"
-            return "\(propertyInfo.name): \(varName)"
-        } else {
-            // 這是非 @Field 屬性，根據類型和預設值決定處理方式
-            if propertyInfo.hasDefaultValue {
-                // 有預設值的屬性不需要在建構子中指定
-                return nil
-            } else if propertyInfo.isOptional {
-                // 可選屬性預設為 nil
-                return "\(propertyInfo.name): nil"
-            } else {
-                // 必需屬性但沒有 @Field - 這是設計問題，直接丟錯，要求提供預設值或改為可選/@Field
-                throw MacroError.missingArguments("Property '\(propertyInfo.name)' is non-optional and not marked with @Field or default value. Provide a default or mark it optional/@Field.")
-            }
-        }
-    }.joined(separator: ",\n            ")
+    // Constructor property list
+    let propertyList = try generatePropertyConstructorList(
+        schemaFields: classification.schemaFields,
+        allProperties: classification.allProperties
+    )
+    
+    return ParsingLogic(
+        optionalExtractions: optionalExtractions,
+        requiredGuardBindings: requiredGuardBindings,
+        requiredPostGuardLines: requiredPostGuardLines,
+        schemaCheckLines: schemaCheckLines,
+        propertyList: propertyList
+    )
+}
 
-    // 針對所有使用到的 nested 型別，強制在編譯期檢查其是否提供 Schema/Parse（由 @Schema 生成）
+private func generateOptionalExtraction(for property: SchemaFieldInfo) -> String {
+    let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+    let baseType = property.type.replacingOccurrences(of: "?", with: "")
+    
+    if swiftTypeToJsonSchemaType(baseType) != nil {
+        return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+    } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
+        let elementType = String(baseType.dropFirst().dropLast())
+        return "let \(varName) = args[\"\(property.name)\"]?.arrayValue?.compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
+    } else {
+        return "let \(varName) = args[\"\(property.name)\"].flatMap { \(baseType).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
+    }
+}
+
+private func generateRequiredFieldLogic(for property: SchemaFieldInfo) -> (String, String?) {
+    let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+    
+    if swiftTypeToJsonSchemaType(property.type) != nil {
+        return ("\(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)", nil)
+    } else if property.type.hasPrefix("[") && property.type.hasSuffix("]") {
+        let elementType = String(property.type.dropFirst().dropLast())
+        let rawName = "raw\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+        let guardBinding = "\(rawName) = args[\"\(property.name)\"]?.arrayValue"
+        let postGuard = "let \(varName) = \(rawName).compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
+        return (guardBinding, postGuard)
+    } else {
+        return ("\(varName) = \(property.type).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())", nil)
+    }
+}
+
+private func generateSchemaTypeChecks(for properties: [SchemaFieldInfo]) -> [String] {
     var schemaCheckLines: [String] = []
+    
     func collectSchemaCheck(for typeName: String) {
         if swiftTypeToJsonSchemaType(typeName) == nil {
             schemaCheckLines.append("_requireSchema(\(typeName).self)")
         }
     }
-    for p in properties {
-        let base = p.type.replacingOccurrences(of: "?", with: "")
-        if base.hasPrefix("[") && base.hasSuffix("]") {
-            let element = String(base.dropFirst().dropLast())
-            if swiftTypeToJsonSchemaType(element) == nil {
-                collectSchemaCheck(for: element)
-            }
+    
+    for property in properties {
+        let baseType = property.type.replacingOccurrences(of: "?", with: "")
+        if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
+            let elementType = String(baseType.dropFirst().dropLast())
+            collectSchemaCheck(for: elementType)
         } else {
-            if swiftTypeToJsonSchemaType(base) == nil {
-                collectSchemaCheck(for: base)
-            }
+            collectSchemaCheck(for: baseType)
         }
     }
+    
+    return schemaCheckLines
+}
+
+private func generatePropertyConstructorList(
+    schemaFields: [SchemaFieldInfo],
+    allProperties: [PropertyInfo]
+) throws -> String {
+    return try allProperties.compactMap { propertyInfo -> String? in
+        if let fieldProperty = schemaFields.first(where: { $0.name == propertyInfo.name }) {
+            // @Field property - use parsed value
+            let varName = "parsed\(fieldProperty.name.prefix(1).uppercased())\(fieldProperty.name.dropFirst())"
+            return "\(propertyInfo.name): \(varName)"
+        } else {
+            // Non-@Field property - handle based on type and defaults
+            if propertyInfo.hasDefaultValue {
+                return nil // Skip properties with default values
+            } else if propertyInfo.isOptional {
+                return "\(propertyInfo.name): nil"
+            } else {
+                throw MacroError.missingArguments("Property '\(propertyInfo.name)' is non-optional and not marked with @Field or default value. Provide a default or mark it optional/@Field.")
+            }
+        }
+    }.joined(separator: ",\n            ")
+}
+
+// MARK: - Extension Assembly
+
+private func assembleExtension(
+    for type: some TypeSyntaxProtocol,
+    protocolName: String,
+    schemaPropertyName: String,
+    parseMethodName: String,
+    parseMethodSignature: String,
+    schemaProperties: String,
+    requiredFields: String,
+    parsingLogic: ParsingLogic
+) throws -> ExtensionDeclSyntax {
     
     let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
     extension \(type): \(raw: protocolName) {
@@ -342,16 +406,53 @@ private func generateSchemaExtension(
         private static func _requireSchema<T: MCP.MCPParameterParsable>(_ type: T.Type) {}
         
         \(raw: parseMethodSignature) {
-            \(raw: parseMethodName == "parseArguments" ? "" : "guard let args = value.objectValue else {\n                return nil\n            }\n\n            ")\(raw: schemaCheckLines.isEmpty ? "" : "\(schemaCheckLines.joined(separator: "\n            "))\n\n            ")\(raw: optionalExtractions.isEmpty ? "" : "\(optionalExtractions.joined(separator: "\n            "))\n\n            ")\(raw: requiredGuardBindings.isEmpty ? "" : "guard let \(requiredGuardBindings.joined(separator: ",\n                let ")) else {\n                return nil\n            }\n\n            ")\(raw: requiredPostGuardLines.isEmpty ? "" : "\(requiredPostGuardLines.joined(separator: "\n            "))\n\n            ")
+            \(raw: parseMethodName == "parseArguments" ? "" : "guard let args = value.objectValue else {\n                return nil\n            }\n\n            ")\(raw: parsingLogic.schemaCheckLines.isEmpty ? "" : "\(parsingLogic.schemaCheckLines.joined(separator: "\n            "))\n\n            ")\(raw: parsingLogic.optionalExtractions.isEmpty ? "" : "\(parsingLogic.optionalExtractions.joined(separator: "\n            "))\n\n            ")\(raw: parsingLogic.requiredGuardBindings.isEmpty ? "" : "guard let \(parsingLogic.requiredGuardBindings.joined(separator: ",\n                let ")) else {\n                return nil\n            }\n\n            ")\(raw: parsingLogic.requiredPostGuardLines.isEmpty ? "" : "\(parsingLogic.requiredPostGuardLines.joined(separator: "\n            "))\n\n            ")
 
             return \(type)(
-                \(raw: propertyList)
+                \(raw: parsingLogic.propertyList)
             )
         }
     }
     """)
     
     return extensionDecl
+}
+
+// MARK: - Main Generation Function
+
+private func generateSchemaExtension(
+    for type: some TypeSyntaxProtocol,
+    from structDecl: StructDeclSyntax,
+    protocolName: String,
+    schemaPropertyName: String,
+    parseMethodName: String,
+    parseMethodSignature: String
+) throws -> ExtensionDeclSyntax {
+    
+    // 1. Classify properties
+    let classification = classifyProperties(from: structDecl)
+    
+    // 2. Generate schema components
+    var root: Syntax = Syntax(structDecl)
+    while let parent = root.parent { root = parent }
+    
+    let schemaProperties = generateAdvancedSchemaProperties(from: classification.schemaFields, in: root)
+    let requiredFields = generateRequiredFields(from: classification.schemaFields)
+    
+    // 3. Generate parsing logic
+    let parsingLogic = try generateParsingLogic(for: classification)
+    
+    // 4. Assemble final extension
+    return try assembleExtension(
+        for: type,
+        protocolName: protocolName,
+        schemaPropertyName: schemaPropertyName,
+        parseMethodName: parseMethodName,
+        parseMethodSignature: parseMethodSignature,
+        schemaProperties: schemaProperties,
+        requiredFields: requiredFields,
+        parsingLogic: parsingLogic
+    )
 }
 
 private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -4,25 +4,35 @@ import SwiftSyntaxBuilder
 
 // MARK: - Schema Field Information
 struct SchemaFieldInfo {
+    // Field name. Used as the key in JSON Schema properties and to read from args during parsing.
     let name: String
+    // Original Swift type string (may include ? or array syntax). Used to decide unwrap strategy and JSON Schema type.
     let type: String
+    // Optional description. Emitted to JSON Schema as "description".
     let description: String?
-    let isRequired: Bool
-    let isOptional: Bool
+    // Business-level required flag:
+    // - Drives inputSchema "required" list
+    // - Decides whether parsing uses guard
+    // Rule: non-optional type AND no default value => true; otherwise false
+    let isRequiredField: Bool
+    // Type-level optionality only. True if the Swift type ends with '?'.
+    // It only affects how we unwrap/convert values, not whether we guard.
+    let isOptionalType: Bool
+    // Extra constraints for JSON Schema (minimum/maximum/enum/minItems/maxItems).
     let constraint: FieldConstraintInfo?
 
     init(
         name: String,
         type: String,
         description: String? = nil,
-        isRequired: Bool = true,
+        isRequiredField: Bool = true,
         constraint: FieldConstraintInfo? = nil
     ) {
         self.name = name
         self.type = type
         self.description = description
-        self.isRequired = isRequired
-        self.isOptional = type.hasSuffix("?")
+        self.isRequiredField = isRequiredField
+        self.isOptionalType = type.hasSuffix("?")
         self.constraint = constraint
     }
 }
@@ -102,8 +112,8 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
             let propertyName = pattern.identifier.text
             let propertyType = typeAnnotation.type.trimmed.description
             var description: String?
-            var isRequired: Bool? = nil
             var constraint: FieldConstraintInfo? = nil
+            let hasDefaultValue = binding.initializer != nil
 
             for attribute in varDecl.attributes {
                 if let attributeNode = attribute.as(AttributeSyntax.self),
@@ -118,10 +128,6 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
                                    let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
                                     description = segment.content.text
                                 }
-                            case "isRequired":
-                                if let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
-                                    isRequired = boolLiteral.literal.text == "true"
-                                }
                             case "constraint":
                                 // Parse FieldConstraint enum value
                                 constraint = parseFieldConstraint(argument.expression)
@@ -133,14 +139,15 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
                 }
             }
 
-            // If isRequired not specified, infer from property type
-            let finalIsRequired = isRequired ?? !propertyType.hasSuffix("?")
+            // Determine isRequired solely by type optionality and presence of a default value
+            // optional OR has default -> not required; non-optional AND no default -> required
+            let finalIsRequired = !propertyType.hasSuffix("?") && !hasDefaultValue
 
             fieldInfos.append(SchemaFieldInfo(
                 name: propertyName,
                 type: propertyType,
                 description: description,
-                isRequired: finalIsRequired,
+                isRequiredField: finalIsRequired,
                 constraint: constraint
             ))
         }
@@ -236,7 +243,7 @@ private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo]
 }
 
 private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> String {
-    let requiredFields = properties.filter { $0.isRequired }.map { ".string(\"\($0.name)\")" }
+    let requiredFields = properties.filter { $0.isRequiredField }.map { ".string(\"\($0.name)\")" }
     return requiredFields.joined(separator: ",\n\(SCHEMA_INDENT)")
 }
 
@@ -253,8 +260,9 @@ private func classifyProperties(from structDecl: StructDeclSyntax) -> PropertyCl
     let schemaFields = extractSchemaFields(from: structDecl)
     let allProperties = extractAllProperties(from: structDecl)
     
-    let optionalFields = schemaFields.filter { $0.isOptional }
-    let requiredFields = schemaFields.filter { !$0.isOptional }
+    // Use isRequiredField to split required and optional so schema and parsing stay consistent
+    let requiredFields = schemaFields.filter { $0.isRequiredField }
+    let optionalFields = schemaFields.filter { !$0.isRequiredField }
     
     return PropertyClassification(
         schemaFields: schemaFields,

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -37,12 +37,79 @@ struct SchemaFieldInfo {
     }
 }
 
+// MARK: - Constraint Validation (compile-time)
+
+private func validateConstraints(for fields: [SchemaFieldInfo]) throws {
+    for field in fields {
+        guard let constraint = field.constraint else { continue }
+        let swiftType = SwiftType(from: field.type)
+
+        func error(_ message: String) throws -> Never { throw MacroError.unsupportedType(message) }
+        let isWhole: (Double) -> Bool = { $0.rounded() == $0 }
+
+        switch swiftType {
+        case .optional(let wrapped):
+            try validateConstraints(for: [SchemaFieldInfo(name: field.name, type: wrapped.baseTypeName, description: field.description, isRequiredField: field.isRequiredField, constraint: field.constraint)])
+        case .basic(let basicType):
+            switch basicType {
+            case .string:
+                switch constraint.type {
+                case .range(let min, let max):
+                    guard isWhole(min), isWhole(max) else {
+                        try error("Property '\(field.name)' of type String requires integer length bounds for .range")
+                    }
+                case .options:
+                    break // OK
+                }
+            case .int:
+                switch constraint.type {
+                case .range(let min, let max):
+                    guard isWhole(min), isWhole(max) else {
+                        try error("Property '\(field.name)' of type Int requires integer bounds for .range")
+                    }
+                case .options:
+                    break // allow enums on ints if desired
+                }
+            case .double, .float:
+                switch constraint.type {
+                case .range:
+                    break // OK
+                case .options:
+                    break
+                }
+            case .bool:
+                try error("Property '\(field.name)' of type Bool does not support range constraints")
+            }
+        case .array:
+            switch constraint.type {
+            case .range(let min, let max):
+                guard isWhole(min), isWhole(max) else {
+                    try error("Property '\(field.name)' of array type requires integer item count bounds for .range")
+                }
+            case .options:
+                // Not typical for arrays; allow or ignore silently
+                break
+            }
+        case .custom:
+            switch constraint.type {
+            case .range:
+                try error("Property '\(field.name)' of custom type does not support range constraints")
+            case .options:
+                break
+            }
+        }
+    }
+}
+
 // MARK: - Field Constraint Information
 struct FieldConstraintInfo {
     enum ConstraintType {
-        case range(min: Int, max: Int)
-        case rangeDouble(min: Double, max: Double)
-        case count(value: Int)
+        // Unified range with Double bounds; integrality is validated per-type where required.
+        // - String: min/max must be integers → minLength/maxLength
+        // - Array:  min/max must be integers → minItems/maxItems
+        // - Int:    min/max must be integers → minimum/maximum (integer)
+        // - Double/Float: doubles allowed     → minimum/maximum (number)
+        case range(min: Double, max: Double)
         case options([String])
     }
 
@@ -192,17 +259,19 @@ private func schemaForProperty(type: SwiftType, description: String?, constraint
         if let constraint = constraint {
             switch constraint.type {
             case .range(let min, let max):
-                components.append("\"minimum\": .int(\(min))")
-                components.append("\"maximum\": .int(\(max))")
-            case .rangeDouble(let min, let max):
-                components.append("\"minimum\": .double(\(min))")
-                components.append("\"maximum\": .double(\(max))")
+                if basicType == .string {
+                    components.append("\"minLength\": .int(\(Int(min)))")
+                    components.append("\"maxLength\": .int(\(Int(max)))")
+                } else if basicType == .double || basicType == .float {
+                    components.append("\"minimum\": .double(\(min))")
+                    components.append("\"maximum\": .double(\(max))")
+                } else {
+                    components.append("\"minimum\": .int(\(Int(min)))")
+                    components.append("\"maximum\": .int(\(Int(max)))")
+                }
             case .options(let values):
                 let enumValuesString = values.map { ".string(\"\($0)\")" }.joined(separator: ", ")
                 components.append("\"enum\": .array([\(enumValuesString)])")
-            case .count:
-                // count applies to arrays; ignore here
-                break
             }
         }
         let body = components.joined(separator: ",\n\(PROPERTY_INDENT)")
@@ -215,9 +284,13 @@ private func schemaForProperty(type: SwiftType, description: String?, constraint
             components.append("\"description\": .string(\"\(description)\")")
         }
         if let constraint = constraint {
-            if case .count(let value) = constraint.type {
-                components.append("\"minItems\": .int(\(value))")
-                components.append("\"maxItems\": .int(\(value))")
+            switch constraint.type {
+            case .range(let min, let max):
+                components.append("\"minItems\": .int(\(Int(min)))")
+                components.append("\"maxItems\": .int(\(Int(max)))")
+            case .options:
+                // options is not typically used for arrays; ignore
+                break
             }
         }
         let body = components.joined(separator: ",\n\(PROPERTY_INDENT)")
@@ -503,6 +576,8 @@ private func generateSchemaExtension(
     // 3. Generate parsing logic
     let parsingLogic = try generateParsingLogic(for: classification)
     
+    try validateConstraints(for: classification.schemaFields)
+
     // 4. Assemble final extension
     return try assembleExtension(
         for: type,
@@ -673,20 +748,9 @@ private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintIn
                 }
             }
         case "range":
-            // Parse .range(0...120)
+            // Parse .range(0...120) or .range(0.0...1.0)
             if let rangeArg = functionCall.arguments.first?.expression {
                 return parseRangeConstraintFromExpression(rangeArg)
-            }
-        case "rangeDouble":
-            // Parse .rangeDouble(0.0...100.0)
-            if let rangeArg = functionCall.arguments.first?.expression {
-                return parseRangeConstraintFromExpression(rangeArg)
-            }
-        case "count":
-            // Parse .count(5)
-            if let intArg = functionCall.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
-               let value = Int(intArg.literal.text) {
-                return FieldConstraintInfo(.count(value: value))
             }
         default:
             break
@@ -707,15 +771,9 @@ private func parseRangeConstraintFromExpression(_ expression: ExprSyntax) -> Fie
             let minStr = minElement.trimmed.description
             let maxStr = maxElement.trimmed.description
             
-            // Check if it's a floating point number
-            if minStr.contains(".") || maxStr.contains(".") {
-                if let minDouble = Double(minStr), let maxDouble = Double(maxStr) {
-                    return FieldConstraintInfo(.rangeDouble(min: minDouble, max: maxDouble))
-                }
-            } else {
-                if let minInt = Int(minStr), let maxInt = Int(maxStr) {
-                    return FieldConstraintInfo(.range(min: minInt, max: maxInt))
-                }
+            // Parse both integer and floating ranges as Double; integrality is validated later per type
+            if let minDouble = Double(minStr), let maxDouble = Double(maxStr) {
+                return FieldConstraintInfo(.range(min: minDouble, max: maxDouble))
             }
         }
     }

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -59,7 +59,7 @@ private func validateConstraints(for fields: [SchemaFieldInfo]) throws {
                         try error("Property '\(field.name)' of type String requires integer length bounds for .range")
                     }
                 case .options:
-                    break // OK
+                    break
                 }
             case .int:
                 switch constraint.type {
@@ -68,12 +68,12 @@ private func validateConstraints(for fields: [SchemaFieldInfo]) throws {
                         try error("Property '\(field.name)' of type Int requires integer bounds for .range")
                     }
                 case .options:
-                    break // allow enums on ints if desired
+                    break
                 }
             case .double, .float:
                 switch constraint.type {
                 case .range:
-                    break // OK
+                    break
                 case .options:
                     break
                 }
@@ -87,7 +87,6 @@ private func validateConstraints(for fields: [SchemaFieldInfo]) throws {
                     try error("Property '\(field.name)' of array type requires integer item count bounds for .range")
                 }
             case .options:
-                // Not typical for arrays; allow or ignore silently
                 break
             }
         case .custom:
@@ -233,7 +232,7 @@ private struct IndentLevel {
     static let property = 5    // 20 spaces for property level
 }
 
-// Legacy constants for compatibility
+// Indent constants for formatting
 private let SCHEMA_INDENT = indent(IndentLevel.schema)
 private let PROPERTY_INDENT = indent(IndentLevel.property)
 
@@ -296,12 +295,11 @@ private func schemaForProperty(type: SwiftType, description: String?, constraint
         let body = components.joined(separator: ",\n\(PROPERTY_INDENT)")
         return ".object([\n\(PROPERTY_INDENT)\(body)\n\(SCHEMA_INDENT)])"
     case .custom(let name):
-        // Delegate to nested schema provider
         return "\(name).inputSchema"
     }
 }
 
-// Generate the schema value for array items (a MCP.Value expression)
+// Generate schema for array items
 private func schemaForItems(type: SwiftType) -> String {
     switch type {
     case .optional(let wrapped):
@@ -334,7 +332,7 @@ private func classifyProperties(from structDecl: StructDeclSyntax) -> PropertyCl
     let schemaFields = extractSchemaFields(from: structDecl)
     let allProperties = extractAllProperties(from: structDecl)
     
-    // Use isRequiredField to split required and optional so schema and parsing stay consistent
+    // Split required and optional via isRequiredField for consistency
     let requiredFields = schemaFields.filter { $0.isRequiredField }
     let optionalFields = schemaFields.filter { !$0.isRequiredField }
     
@@ -403,7 +401,7 @@ private func generateOptionalExtraction(for property: SchemaFieldInfo) -> String
     case .optional(let wrapped):
         return generateOptionalExtractionForType(varName: varName, propertyName: property.name, type: wrapped)
     default:
-        // This shouldn't happen for optional properties, but handle gracefully
+        // Fallback for unexpected optional typing
         return generateOptionalExtractionForType(varName: varName, propertyName: property.name, type: swiftType)
     }
 }
@@ -424,7 +422,7 @@ private func generateOptionalExtractionForType(varName: String, propertyName: St
     case .custom(let typeName):
         return "let \(varName) = args[\"\(propertyName)\"].flatMap { \(typeName).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
     case .optional:
-        // Nested optionals, shouldn't happen in well-formed types
+        // Fallback for nested optionals
         return "let \(varName) = args[\"\(propertyName)\"] /* TODO: Nested optional */"
     }
 }
@@ -454,7 +452,7 @@ private func generateRequiredFieldLogic(for property: SchemaFieldInfo) -> (Strin
     case .custom(let typeName):
         return ("\(varName) = \(typeName).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())", nil)
     case .optional:
-        // Required fields shouldn't be optional, but handle gracefully
+        // Fallback: required optional
         return ("\(varName) = /* TODO: Required optional */ nil", nil)
     }
 }
@@ -466,7 +464,7 @@ private func generateSchemaTypeChecks(for properties: [SchemaFieldInfo]) -> [Str
     func collectSchemaCheck(for type: SwiftType) {
         switch type {
         case .basic:
-            // No schema check needed for basic types
+            // No schema check for basic types
             break
         case .array(let element):
             collectSchemaCheck(for: element)
@@ -494,11 +492,11 @@ private func generatePropertyConstructorList(
 ) throws -> String {
     return try allProperties.compactMap { propertyInfo -> String? in
         if let fieldProperty = schemaFields.first(where: { $0.name == propertyInfo.name }) {
-            // @Field property - use parsed value
+            // Use parsed value for @Field property
             let varName = "parsed\(fieldProperty.name.prefix(1).uppercased())\(fieldProperty.name.dropFirst())"
             return "\(propertyInfo.name): \(varName)"
         } else {
-            // Non-@Field property - handle based on type and defaults
+            // For non-@Field, handle by defaults and optionality
             if propertyInfo.hasDefaultValue {
                 return nil // Skip properties with default values
             } else if propertyInfo.isOptional {
@@ -678,9 +676,7 @@ indirect enum SwiftType {
     }
 }
 
-private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
-    return SwiftType(from: swiftType).jsonSchemaType
-}
+// Removed: swiftTypeToJsonSchemaType(_:) was unused
 
 
 // MARK: - Schema Macro (Simpler API)

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -45,7 +45,7 @@ struct FieldConstraintInfo {
 
 // MARK: - Helper Methods
 
-// 描述所有屬性的基本資訊
+// Describes basic information about all properties
 struct PropertyInfo {
     let name: String
     let type: String
@@ -79,7 +79,7 @@ private func extractAllProperties(from structDecl: StructDeclSyntax) -> [Propert
 }
 
 private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFieldInfo] {
-    // 方案A：直接解析 @Field 標註的屬性（仿照 Foundation Models）
+    // Approach A: Parse @Field marked properties directly (following Foundation Models pattern)
     var fieldInfos: [SchemaFieldInfo] = []
     
     for member in structDecl.memberBlock.members {
@@ -88,7 +88,7 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
            let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
            let typeAnnotation = binding.typeAnnotation {
 
-            // 檢查是否有 @Field 屬性
+            // Check if property has @Field attribute
             let hasFieldAttribute = varDecl.attributes.contains { attribute in
                 if let attributeNode = attribute.as(AttributeSyntax.self),
                    let identifier = attributeNode.attributeName.as(IdentifierTypeSyntax.self) {
@@ -123,7 +123,7 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
                                     isRequired = boolLiteral.literal.text == "true"
                                 }
                             case "constraint":
-                                // 解析 FieldConstraint 枚舉值
+                                // Parse FieldConstraint enum value
                                 constraint = parseFieldConstraint(argument.expression)
                             default:
                                 break
@@ -133,7 +133,7 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
                 }
             }
 
-            // 如果未明確指定 isRequired，根據屬性類型推斷
+            // If isRequired not specified, infer from property type
             let finalIsRequired = isRequired ?? !propertyType.hasSuffix("?")
 
             fieldInfos.append(SchemaFieldInfo(
@@ -148,9 +148,20 @@ private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFi
     return fieldInfos
 }
 
-// 縮排常數  
-private let SCHEMA_INDENT = "                "        // 16 spaces for schema level
-private let PROPERTY_INDENT = "                    "  // 20 spaces for property level
+// MARK: - String Template System
+
+private func indent(_ level: Int) -> String {
+    return String(repeating: "    ", count: level)
+}
+
+private struct IndentLevel {
+    static let schema = 4      // 16 spaces for schema level
+    static let property = 5    // 20 spaces for property level
+}
+
+// Legacy constants for compatibility
+private let SCHEMA_INDENT = indent(IndentLevel.schema)
+private let PROPERTY_INDENT = indent(IndentLevel.property)
 
 private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo], in root: Syntax) -> String {
     return properties.map { property in
@@ -304,51 +315,92 @@ private func generateParsingLogic(
 
 private func generateOptionalExtraction(for property: SchemaFieldInfo) -> String {
     let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
-    let baseType = property.type.replacingOccurrences(of: "?", with: "")
+    let swiftType = SwiftType(from: property.type)
     
-    if swiftTypeToJsonSchemaType(baseType) != nil {
-        return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
-    } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
-        let elementType = String(baseType.dropFirst().dropLast())
-        return "let \(varName) = args[\"\(property.name)\"]?.arrayValue?.compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
-    } else {
-        return "let \(varName) = args[\"\(property.name)\"].flatMap { \(baseType).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
+    switch swiftType {
+    case .optional(let wrapped):
+        return generateOptionalExtractionForType(varName: varName, propertyName: property.name, type: wrapped)
+    default:
+        // This shouldn't happen for optional properties, but handle gracefully
+        return generateOptionalExtractionForType(varName: varName, propertyName: property.name, type: swiftType)
+    }
+}
+
+private func generateOptionalExtractionForType(varName: String, propertyName: String, type: SwiftType) -> String {
+    switch type {
+    case .basic(let basicType):
+        return "let \(varName) = \(basicType.rawValue)(args[\"\(propertyName)\"] ?? .null)"
+    case .array(let element):
+        switch element {
+        case .basic(let basicType):
+            return "let \(varName) = args[\"\(propertyName)\"]?.arrayValue?.compactMap({ \(basicType.rawValue)($0) })"
+        case .custom(let typeName):
+            return "let \(varName) = args[\"\(propertyName)\"]?.arrayValue?.compactMap({ \(typeName).parseArguments($0.objectValue ?? [:]) })"
+        default:
+            return "let \(varName) = args[\"\(propertyName)\"]?.arrayValue?.compactMap({ /* TODO: Complex array element */ })"
+        }
+    case .custom(let typeName):
+        return "let \(varName) = args[\"\(propertyName)\"].flatMap { \(typeName).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
+    case .optional:
+        // Nested optionals, shouldn't happen in well-formed types
+        return "let \(varName) = args[\"\(propertyName)\"] /* TODO: Nested optional */"
     }
 }
 
 private func generateRequiredFieldLogic(for property: SchemaFieldInfo) -> (String, String?) {
     let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+    let swiftType = SwiftType(from: property.type)
     
-    if swiftTypeToJsonSchemaType(property.type) != nil {
-        return ("\(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)", nil)
-    } else if property.type.hasPrefix("[") && property.type.hasSuffix("]") {
-        let elementType = String(property.type.dropFirst().dropLast())
+    switch swiftType {
+    case .basic(let basicType):
+        return ("\(varName) = \(basicType.rawValue)(args[\"\(property.name)\"] ?? .null)", nil)
+    case .array(let element):
         let rawName = "raw\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
         let guardBinding = "\(rawName) = args[\"\(property.name)\"]?.arrayValue"
-        let postGuard = "let \(varName) = \(rawName).compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
-        return (guardBinding, postGuard)
-    } else {
-        return ("\(varName) = \(property.type).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())", nil)
+        
+        switch element {
+        case .basic(let basicType):
+            let postGuard = "let \(varName) = \(rawName).compactMap({ \(basicType.rawValue)($0) })"
+            return (guardBinding, postGuard)
+        case .custom(let typeName):
+            let postGuard = "let \(varName) = \(rawName).compactMap({ \(typeName).parseArguments($0.objectValue ?? [:]) })"
+            return (guardBinding, postGuard)
+        default:
+            let postGuard = "let \(varName) = \(rawName) /* TODO: Complex array element */"
+            return (guardBinding, postGuard)
+        }
+    case .custom(let typeName):
+        return ("\(varName) = \(typeName).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())", nil)
+    case .optional:
+        // Required fields shouldn't be optional, but handle gracefully
+        return ("\(varName) = /* TODO: Required optional */ nil", nil)
     }
 }
 
 private func generateSchemaTypeChecks(for properties: [SchemaFieldInfo]) -> [String] {
     var schemaCheckLines: [String] = []
+    var checkedTypes: Set<String> = []
     
-    func collectSchemaCheck(for typeName: String) {
-        if swiftTypeToJsonSchemaType(typeName) == nil {
-            schemaCheckLines.append("_requireSchema(\(typeName).self)")
+    func collectSchemaCheck(for type: SwiftType) {
+        switch type {
+        case .basic:
+            // No schema check needed for basic types
+            break
+        case .array(let element):
+            collectSchemaCheck(for: element)
+        case .optional(let wrapped):
+            collectSchemaCheck(for: wrapped)
+        case .custom(let typeName):
+            if !checkedTypes.contains(typeName) {
+                checkedTypes.insert(typeName)
+                schemaCheckLines.append("_requireSchema(\(typeName).self)")
+            }
         }
     }
     
     for property in properties {
-        let baseType = property.type.replacingOccurrences(of: "?", with: "")
-        if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
-            let elementType = String(baseType.dropFirst().dropLast())
-            collectSchemaCheck(for: elementType)
-        } else {
-            collectSchemaCheck(for: baseType)
-        }
+        let swiftType = SwiftType(from: property.type)
+        collectSchemaCheck(for: swiftType)
     }
     
     return schemaCheckLines
@@ -455,19 +507,95 @@ private func generateSchemaExtension(
     )
 }
 
-private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
-    switch swiftType {
-    case "String":
-        return "string"
-    case "Int":
-        return "integer"
-    case "Double", "Float":
-        return "number"
-    case "Bool":
-        return "boolean"
-    default:
-        return nil
+// MARK: - Type Classification System
+
+indirect enum SwiftType {
+    case basic(BasicType)
+    case array(element: SwiftType)
+    case optional(wrapped: SwiftType)
+    case custom(String)
+    
+    enum BasicType: String, CaseIterable {
+        case string = "String"
+        case int = "Int"
+        case double = "Double"
+        case float = "Float"
+        case bool = "Bool"
+        
+        var jsonSchemaType: String {
+            switch self {
+            case .string: return "string"
+            case .int: return "integer"
+            case .double, .float: return "number"
+            case .bool: return "boolean"
+            }
+        }
     }
+    
+    init(from typeString: String) {
+        let cleanType = typeString.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Handle optional types
+        if cleanType.hasSuffix("?") {
+            let wrappedType = String(cleanType.dropLast())
+            self = .optional(wrapped: SwiftType(from: wrappedType))
+            return
+        }
+        
+        // Handle array types
+        if cleanType.hasPrefix("[") && cleanType.hasSuffix("]") {
+            let elementType = String(cleanType.dropFirst().dropLast())
+            self = .array(element: SwiftType(from: elementType))
+            return
+        }
+        
+        // Handle basic types
+        if let basicType = BasicType(rawValue: cleanType) {
+            self = .basic(basicType)
+            return
+        }
+        
+        // Custom/nested types
+        self = .custom(cleanType)
+    }
+    
+    var jsonSchemaType: String? {
+        switch self {
+        case .basic(let basicType):
+            return basicType.jsonSchemaType
+        case .array:
+            return "array"
+        case .optional(let wrapped):
+            return wrapped.jsonSchemaType
+        case .custom:
+            return nil
+        }
+    }
+    
+    var isBasicType: Bool {
+        switch self {
+        case .basic: return true
+        case .optional(let wrapped): return wrapped.isBasicType
+        default: return false
+        }
+    }
+    
+    var baseTypeName: String {
+        switch self {
+        case .basic(let basicType):
+            return basicType.rawValue
+        case .array(let element):
+            return "[\(element.baseTypeName)]"
+        case .optional(let wrapped):
+            return wrapped.baseTypeName
+        case .custom(let name):
+            return name
+        }
+    }
+}
+
+private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
+    return SwiftType(from: swiftType).jsonSchemaType
 }
 
 
@@ -506,15 +634,15 @@ public struct FieldMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // 方案A：@Field 純標記性質，不生成任何代碼（仿照 Foundation Models 的 @Guide）
-        // 所有資訊將在 @Schema/@NestedSchema 展開時直接從 AST 解析
+        // Approach A: @Field is pure annotation, generates no code (following Foundation Models' @Guide)
+        // All information will be parsed directly from AST during @Schema expansion
         return []
     }
 }
 
-// 解析 FieldConstraint 枚舉值
+// Parse FieldConstraint enum values
 private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintInfo? {
-    // 處理 .options(["value1", "value2"]) 等格式  
+    // Handle formats like .options(["value1", "value2"])  
     if let functionCall = expression.as(FunctionCallExprSyntax.self),
        let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self) {
         
@@ -522,7 +650,7 @@ private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintIn
         
         switch memberName {
         case "options":
-            // 解析 .options(["light", "dark"])
+            // Parse .options(["light", "dark"])
             if let arrayArg = functionCall.arguments.first?.expression.as(ArrayExprSyntax.self) {
                 let options = arrayArg.elements.compactMap { element -> String? in
                     if let stringLiteral = element.expression.as(StringLiteralExprSyntax.self),
@@ -536,17 +664,17 @@ private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintIn
                 }
             }
         case "range":
-            // 解析 .range(0...120)
+            // Parse .range(0...120)
             if let rangeArg = functionCall.arguments.first?.expression {
                 return parseRangeConstraintFromExpression(rangeArg)
             }
         case "rangeDouble":
-            // 解析 .rangeDouble(0.0...100.0)
+            // Parse .rangeDouble(0.0...100.0)
             if let rangeArg = functionCall.arguments.first?.expression {
                 return parseRangeConstraintFromExpression(rangeArg)
             }
         case "count":
-            // 解析 .count(5)
+            // Parse .count(5)
             if let intArg = functionCall.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
                let value = Int(intArg.literal.text) {
                 return FieldConstraintInfo(.count(value: value))
@@ -558,9 +686,9 @@ private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintIn
     return nil
 }
 
-// 合併重複的約束解析邏輯
+// Combine duplicate constraint parsing logic
 private func parseRangeConstraintFromExpression(_ expression: ExprSyntax) -> FieldConstraintInfo? {
-    // 統一處理 ClosedRange 表達式 (0...120, 0.0...100.0)
+    // Handle ClosedRange expressions uniformly (0...120, 0.0...100.0)
     if let sequenceExpr = expression.as(SequenceExprSyntax.self) {
         let elements = sequenceExpr.elements
         if elements.count >= 3,
@@ -570,7 +698,7 @@ private func parseRangeConstraintFromExpression(_ expression: ExprSyntax) -> Fie
             let minStr = minElement.trimmed.description
             let maxStr = maxElement.trimmed.description
             
-            // 檢查是否為浮點數
+            // Check if it's a floating point number
             if minStr.contains(".") || maxStr.contains(".") {
                 if let minDouble = Double(minStr), let maxDouble = Double(maxStr) {
                     return FieldConstraintInfo(.rangeDouble(min: minDouble, max: maxDouble))

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -369,20 +369,6 @@ private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
     }
 }
 
-private func generateSafeDefault(for type: String) -> String {
-    // 為非 @Field 屬性生成類型安全的預設值
-    if type.contains("String") && !type.hasSuffix("?") {
-        return "\"\""
-    } else if type.contains("Int") && !type.hasSuffix("?") {
-        return "0"
-    } else if type.contains("Bool") && !type.hasSuffix("?") {
-        return "false"
-    } else if type.hasPrefix("[") && type.hasSuffix("]") {
-        return "[]"
-    } else {
-        return "nil"
-    }
-}
 
 // MARK: - Schema Macro (Simpler API)
 

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -1,0 +1,518 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
+
+// MARK: - Schema Field Information
+struct SchemaFieldInfo {
+    let name: String
+    let type: String
+    let description: String?
+    let isRequired: Bool
+    let isOptional: Bool
+    let constraint: FieldConstraintInfo?
+
+    init(
+        name: String,
+        type: String,
+        description: String? = nil,
+        isRequired: Bool = true,
+        constraint: FieldConstraintInfo? = nil
+    ) {
+        self.name = name
+        self.type = type
+        self.description = description
+        self.isRequired = isRequired
+        self.isOptional = type.hasSuffix("?")
+        self.constraint = constraint
+    }
+}
+
+// MARK: - Field Constraint Information
+struct FieldConstraintInfo {
+    enum ConstraintType {
+        case range(min: Int, max: Int)
+        case rangeDouble(min: Double, max: Double)
+        case count(value: Int)
+        case options([String])
+    }
+
+    let type: ConstraintType
+
+    init(_ type: ConstraintType) {
+        self.type = type
+    }
+}
+
+// MARK: - Helper Methods
+
+// 描述所有屬性的基本資訊
+struct PropertyInfo {
+    let name: String
+    let type: String
+    let isOptional: Bool
+    let hasDefaultValue: Bool
+}
+
+private func extractAllProperties(from structDecl: StructDeclSyntax) -> [PropertyInfo] {
+    var allProperties: [PropertyInfo] = []
+
+    for member in structDecl.memberBlock.members {
+        if let varDecl = member.decl.as(VariableDeclSyntax.self),
+           let binding = varDecl.bindings.first,
+           let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+           let typeAnnotation = binding.typeAnnotation {
+
+            let propertyName = pattern.identifier.text
+            let propertyType = typeAnnotation.type.trimmed.description
+            let isOptional = propertyType.hasSuffix("?")
+            let hasDefaultValue = binding.initializer != nil
+
+            allProperties.append(PropertyInfo(
+                name: propertyName,
+                type: propertyType,
+                isOptional: isOptional,
+                hasDefaultValue: hasDefaultValue
+            ))
+        }
+    }
+    return allProperties
+}
+
+private func extractSchemaFields(from structDecl: StructDeclSyntax) -> [SchemaFieldInfo] {
+    // 方案A：直接解析 @Field 標註的屬性（仿照 Foundation Models）
+    var fieldInfos: [SchemaFieldInfo] = []
+    
+    for member in structDecl.memberBlock.members {
+        if let varDecl = member.decl.as(VariableDeclSyntax.self),
+           let binding = varDecl.bindings.first,
+           let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+           let typeAnnotation = binding.typeAnnotation {
+
+            // 檢查是否有 @Field 屬性
+            let hasFieldAttribute = varDecl.attributes.contains { attribute in
+                if let attributeNode = attribute.as(AttributeSyntax.self),
+                   let identifier = attributeNode.attributeName.as(IdentifierTypeSyntax.self) {
+                    return identifier.name.text == "Field"
+                }
+                return false
+            }
+
+            guard hasFieldAttribute else { continue }
+
+            let propertyName = pattern.identifier.text
+            let propertyType = typeAnnotation.type.trimmed.description
+            var description: String?
+            var isRequired: Bool? = nil
+            var constraint: FieldConstraintInfo? = nil
+
+            for attribute in varDecl.attributes {
+                if let attributeNode = attribute.as(AttributeSyntax.self),
+                   let identifier = attributeNode.attributeName.as(IdentifierTypeSyntax.self),
+                   identifier.name.text == "Field" {
+                    
+                    if let arguments = attributeNode.arguments?.as(LabeledExprListSyntax.self) {
+                        for argument in arguments {
+                            switch argument.label?.text {
+                            case "description":
+                                if let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self),
+                                   let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                                    description = segment.content.text
+                                }
+                            case "isRequired":
+                                if let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
+                                    isRequired = boolLiteral.literal.text == "true"
+                                }
+                            case "constraint":
+                                // 解析 FieldConstraint 枚舉值
+                                constraint = parseFieldConstraint(argument.expression)
+                            default:
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 如果未明確指定 isRequired，根據屬性類型推斷
+            let finalIsRequired = isRequired ?? !propertyType.hasSuffix("?")
+
+            fieldInfos.append(SchemaFieldInfo(
+                name: propertyName,
+                type: propertyType,
+                description: description,
+                isRequired: finalIsRequired,
+                constraint: constraint
+            ))
+        }
+    }
+    return fieldInfos
+}
+
+// 縮排常數  
+private let SCHEMA_INDENT = "                "        // 16 spaces for schema level
+private let PROPERTY_INDENT = "                    "  // 20 spaces for property level
+
+private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo], in root: Syntax) -> String {
+    return properties.map { property in
+        let baseType = property.type.replacingOccurrences(of: "?", with: "")
+        if let jsonSchemaType = swiftTypeToJsonSchemaType(baseType) {
+            var schemaComponents: [String] = ["\"type\": .string(\"\(jsonSchemaType)\")"]
+
+            if let description = property.description {
+                schemaComponents.append("\"description\": .string(\"\(description)\")")
+            }
+
+            // Add constraint properties to JSON Schema
+            if let constraint = property.constraint {
+                switch constraint.type {
+                case .range(let min, let max):
+                    schemaComponents.append("\"minimum\": .int(\(min))")
+                    schemaComponents.append("\"maximum\": .int(\(max))")
+                case .rangeDouble(let min, let max):
+                    schemaComponents.append("\"minimum\": .double(\(min))")
+                    schemaComponents.append("\"maximum\": .double(\(max))")
+                case .count(_):
+                    // This will be handled in array processing section
+                    break
+                case .options(let values):
+                    let enumValuesString = values.map { ".string(\"\($0)\")" }.joined(separator: ", ")
+                    schemaComponents.append("\"enum\": .array([\(enumValuesString)])")
+                }
+            }
+
+            let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
+            return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
+        } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
+            // Handle array types
+            let elementType = String(baseType.dropFirst().dropLast()) // Remove [ and ]
+            if let jsonSchemaType = swiftTypeToJsonSchemaType(elementType) {
+                var schemaComponents: [String] = ["\"type\": .string(\"array\")"]
+                schemaComponents.append("\"items\": .object([\"type\": .string(\"\(jsonSchemaType)\")])")
+
+                if let description = property.description {
+                    schemaComponents.append("\"description\": .string(\"\(description)\")")
+                }
+
+                // Add array-specific constraints
+                if let constraint = property.constraint {
+                    switch constraint.type {
+                    case .count(let value):
+                        schemaComponents.append("\"minItems\": .int(\(value))")
+                        schemaComponents.append("\"maxItems\": .int(\(value))")
+                    default:
+                        break
+                    }
+                }
+
+                let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
+                return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
+            } else {
+                // Assume nested @Schema type; let the compiler enforce conformance via helper
+                var schemaComponents: [String] = ["\"type\": .string(\"array\")"]
+                schemaComponents.append("\"items\": \(elementType).inputSchema")
+
+                if let description = property.description {
+                    schemaComponents.append("\"description\": .string(\"\(description)\")")
+                }
+
+                let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
+                return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
+            }
+        } else {
+            return "\"\(property.name)\": \(baseType).inputSchema"
+        }
+    }.joined(separator: ",\n\(SCHEMA_INDENT)")
+}
+
+private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> String {
+    let requiredFields = properties.filter { $0.isRequired }.map { ".string(\"\($0.name)\")" }
+    return requiredFields.joined(separator: ",\n\(SCHEMA_INDENT)")
+}
+
+// 共用的 macro 展開邏輯
+private func generateSchemaExtension(
+    for type: some TypeSyntaxProtocol,
+    from structDecl: StructDeclSyntax,
+    protocolName: String,
+    schemaPropertyName: String,
+    parseMethodName: String,
+    parseMethodSignature: String
+) throws -> ExtensionDeclSyntax {
+    let properties = extractSchemaFields(from: structDecl)
+    var root: Syntax = Syntax(structDecl)
+    while let parent = root.parent { root = parent }
+
+    let schemaProperties = generateAdvancedSchemaProperties(from: properties, in: root)
+    let requiredFields = generateRequiredFields(from: properties)
+
+    // 分離可選和必需字段的解析邏輯
+    let optionalProperties = properties.filter { $0.isOptional }
+    let requiredProperties = properties.filter { !$0.isOptional }
+    
+    let optionalExtractions = optionalProperties.map { property in
+        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+        let baseType = property.type.replacingOccurrences(of: "?", with: "")
+        
+        if swiftTypeToJsonSchemaType(baseType) != nil {
+            return "let \(varName) = \(baseType)(args[\"\(property.name)\"] ?? .null)"
+        } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
+            let elementType = String(baseType.dropFirst().dropLast())
+            return "let \(varName) = args[\"\(property.name)\"]?.arrayValue?.compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })"
+        } else {
+            return "let \(varName) = args[\"\(property.name)\"].flatMap { \(baseType).parseArguments($0.objectValue ?? Dictionary<String, MCP.Value>()) }"
+        }
+    }
+    
+    // 必填欄位：將需要 Optional 綁定的條件放入 guard，並在 guard 之後做必要的後處理（例如必填陣列的解析）
+    var requiredGuardBindings: [String] = []
+    var requiredPostGuardLines: [String] = []
+    for property in requiredProperties {
+        let varName = "parsed\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+        if swiftTypeToJsonSchemaType(property.type) != nil {
+            requiredGuardBindings.append("\(varName) = \(property.type)(args[\"\(property.name)\"] ?? .null)")
+        } else if property.type.hasPrefix("[") && property.type.hasSuffix("]") {
+            let elementType = String(property.type.dropFirst().dropLast())
+            let rawName = "raw\(property.name.prefix(1).uppercased())\(property.name.dropFirst())"
+            requiredGuardBindings.append("\(rawName) = args[\"\(property.name)\"]?.arrayValue")
+            requiredPostGuardLines.append("let \(varName) = \(rawName).compactMap({ \(elementType).parseArguments($0.objectValue ?? [:]) })")
+        } else {
+            requiredGuardBindings.append("\(varName) = \(property.type).parseArguments(args[\"\(property.name)\"]?.objectValue ?? Dictionary<String, MCP.Value>())")
+        }
+    }
+    
+    // propertyExtractions 不再需要，因為我們已經分離了可選和必需字段的處理
+    
+    // 提取所有屬性（包含非 @Field 的屬性）來生成完整的建構子呼叫
+    let allProperties = extractAllProperties(from: structDecl)
+    let propertyList = try allProperties.compactMap { propertyInfo -> String? in
+        if let fieldProperty = properties.first(where: { $0.name == propertyInfo.name }) {
+            // 這是 @Field 屬性，使用解析出的值
+            let varName = "parsed\(fieldProperty.name.prefix(1).uppercased())\(fieldProperty.name.dropFirst())"
+            return "\(propertyInfo.name): \(varName)"
+        } else {
+            // 這是非 @Field 屬性，根據類型和預設值決定處理方式
+            if propertyInfo.hasDefaultValue {
+                // 有預設值的屬性不需要在建構子中指定
+                return nil
+            } else if propertyInfo.isOptional {
+                // 可選屬性預設為 nil
+                return "\(propertyInfo.name): nil"
+            } else {
+                // 必需屬性但沒有 @Field - 這是設計問題，直接丟錯，要求提供預設值或改為可選/@Field
+                throw MacroError.missingArguments("Property '\(propertyInfo.name)' is non-optional and not marked with @Field or default value. Provide a default or mark it optional/@Field.")
+            }
+        }
+    }.joined(separator: ",\n            ")
+
+    // 針對所有使用到的 nested 型別，強制在編譯期檢查其是否提供 Schema/Parse（由 @Schema 生成）
+    var schemaCheckLines: [String] = []
+    func collectSchemaCheck(for typeName: String) {
+        if swiftTypeToJsonSchemaType(typeName) == nil {
+            schemaCheckLines.append("_requireSchema(\(typeName).self)")
+        }
+    }
+    for p in properties {
+        let base = p.type.replacingOccurrences(of: "?", with: "")
+        if base.hasPrefix("[") && base.hasSuffix("]") {
+            let element = String(base.dropFirst().dropLast())
+            if swiftTypeToJsonSchemaType(element) == nil {
+                collectSchemaCheck(for: element)
+            }
+        } else {
+            if swiftTypeToJsonSchemaType(base) == nil {
+                collectSchemaCheck(for: base)
+            }
+        }
+    }
+    
+    let extensionDecl: ExtensionDeclSyntax = try ExtensionDeclSyntax("""
+    extension \(type): \(raw: protocolName) {
+        public static var \(raw: schemaPropertyName): MCP.Value {
+            .object([
+                "type": .string("object"),
+                "properties": .object([
+                    \(raw: schemaProperties)
+                ])\(raw: requiredFields.isEmpty ? "" : ",\n            \"required\": .array([\n\(SCHEMA_INDENT)\(requiredFields)\n            ])")
+            ])
+        }
+        
+        // Compile-time requirement: nested types must provide schema/parse via @Schema
+        @available(*, unavailable, message: "Please annotate this type with @Schema to enable MCP schema and parsing.")
+        private static func _requireSchema(_ type: Any.Type) {}
+        private static func _requireSchema<T: MCP.MCPParameterParsable>(_ type: T.Type) {}
+        
+        \(raw: parseMethodSignature) {
+            \(raw: parseMethodName == "parseArguments" ? "" : "guard let args = value.objectValue else {\n                return nil\n            }\n\n            ")\(raw: schemaCheckLines.isEmpty ? "" : "\(schemaCheckLines.joined(separator: "\n            "))\n\n            ")\(raw: optionalExtractions.isEmpty ? "" : "\(optionalExtractions.joined(separator: "\n            "))\n\n            ")\(raw: requiredGuardBindings.isEmpty ? "" : "guard let \(requiredGuardBindings.joined(separator: ",\n                let ")) else {\n                return nil\n            }\n\n            ")\(raw: requiredPostGuardLines.isEmpty ? "" : "\(requiredPostGuardLines.joined(separator: "\n            "))\n\n            ")
+
+            return \(type)(
+                \(raw: propertyList)
+            )
+        }
+    }
+    """)
+    
+    return extensionDecl
+}
+
+private func swiftTypeToJsonSchemaType(_ swiftType: String) -> String? {
+    switch swiftType {
+    case "String":
+        return "string"
+    case "Int":
+        return "integer"
+    case "Double", "Float":
+        return "number"
+    case "Bool":
+        return "boolean"
+    default:
+        return nil
+    }
+}
+
+private func generateSafeDefault(for type: String) -> String {
+    // 為非 @Field 屬性生成類型安全的預設值
+    if type.contains("String") && !type.hasSuffix("?") {
+        return "\"\""
+    } else if type.contains("Int") && !type.hasSuffix("?") {
+        return "0"
+    } else if type.contains("Bool") && !type.hasSuffix("?") {
+        return "false"
+    } else if type.hasPrefix("[") && type.hasSuffix("]") {
+        return "[]"
+    } else {
+        return "nil"
+    }
+}
+
+// MARK: - Schema Macro (Simpler API)
+
+public struct SchemaMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            throw MacroError.invalidDeclaration("@Schema can only be applied to structs")
+        }
+
+        let extensionDecl = try generateSchemaExtension(
+            for: type,
+            from: structDecl,
+            protocolName: "MCP.MCPParameterParsable",
+            schemaPropertyName: "inputSchema",
+            parseMethodName: "parseArguments",
+            parseMethodSignature: "public static func parseArguments(_ args: [String: MCP.Value]) -> \(type)?"
+        )
+
+        return [extensionDecl]
+    }
+}
+
+// MARK: - Field Macro
+
+public struct FieldMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // 方案A：@Field 純標記性質，不生成任何代碼（仿照 Foundation Models 的 @Guide）
+        // 所有資訊將在 @Schema/@NestedSchema 展開時直接從 AST 解析
+        return []
+    }
+}
+
+// 解析 FieldConstraint 枚舉值
+private func parseFieldConstraint(_ expression: ExprSyntax) -> FieldConstraintInfo? {
+    // 處理 .options(["value1", "value2"]) 等格式  
+    if let functionCall = expression.as(FunctionCallExprSyntax.self),
+       let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self) {
+        
+        let memberName = memberAccess.declName.baseName.text
+        
+        switch memberName {
+        case "options":
+            // 解析 .options(["light", "dark"])
+            if let arrayArg = functionCall.arguments.first?.expression.as(ArrayExprSyntax.self) {
+                let options = arrayArg.elements.compactMap { element -> String? in
+                    if let stringLiteral = element.expression.as(StringLiteralExprSyntax.self),
+                       let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                        return segment.content.text
+                    }
+                    return nil
+                }
+                if !options.isEmpty {
+                    return FieldConstraintInfo(.options(options))
+                }
+            }
+        case "range":
+            // 解析 .range(0...120)
+            if let rangeArg = functionCall.arguments.first?.expression {
+                return parseRangeConstraintFromExpression(rangeArg)
+            }
+        case "rangeDouble":
+            // 解析 .rangeDouble(0.0...100.0)
+            if let rangeArg = functionCall.arguments.first?.expression {
+                return parseRangeConstraintFromExpression(rangeArg)
+            }
+        case "count":
+            // 解析 .count(5)
+            if let intArg = functionCall.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
+               let value = Int(intArg.literal.text) {
+                return FieldConstraintInfo(.count(value: value))
+            }
+        default:
+            break
+        }
+    }
+    return nil
+}
+
+// 合併重複的約束解析邏輯
+private func parseRangeConstraintFromExpression(_ expression: ExprSyntax) -> FieldConstraintInfo? {
+    // 統一處理 ClosedRange 表達式 (0...120, 0.0...100.0)
+    if let sequenceExpr = expression.as(SequenceExprSyntax.self) {
+        let elements = sequenceExpr.elements
+        if elements.count >= 3,
+           let minElement = elements.first?.as(ExprSyntax.self),
+           let maxElement = elements.last?.as(ExprSyntax.self) {
+            
+            let minStr = minElement.trimmed.description
+            let maxStr = maxElement.trimmed.description
+            
+            // 檢查是否為浮點數
+            if minStr.contains(".") || maxStr.contains(".") {
+                if let minDouble = Double(minStr), let maxDouble = Double(maxStr) {
+                    return FieldConstraintInfo(.rangeDouble(min: minDouble, max: maxDouble))
+                }
+            } else {
+                if let minInt = Int(minStr), let maxInt = Int(maxStr) {
+                    return FieldConstraintInfo(.range(min: minInt, max: maxInt))
+                }
+            }
+        }
+    }
+    return nil
+}
+
+// MARK: - Error Types
+
+enum MacroError: Error, CustomStringConvertible {
+    case invalidDeclaration(String)
+    case missingArguments(String)
+    case unsupportedType(String)
+    
+    var description: String {
+        switch self {
+        case .invalidDeclaration(let message):
+            return "Invalid declaration: \(message)"
+        case .missingArguments(let message):
+            return "Missing arguments: \(message)"
+        case .unsupportedType(let message):
+            return "Unsupported type: \(message)"
+        }
+    }
+}

--- a/Sources/MCPToolMacros/ToolRegistrationMacro.swift
+++ b/Sources/MCPToolMacros/ToolRegistrationMacro.swift
@@ -172,74 +172,75 @@ private let PROPERTY_INDENT = indent(IndentLevel.property)
 
 private func generateAdvancedSchemaProperties(from properties: [SchemaFieldInfo], in root: Syntax) -> String {
     return properties.map { property in
-        let baseType = property.type.replacingOccurrences(of: "?", with: "")
-        if let jsonSchemaType = swiftTypeToJsonSchemaType(baseType) {
-            var schemaComponents: [String] = ["\"type\": .string(\"\(jsonSchemaType)\")"]
-
-            if let description = property.description {
-                schemaComponents.append("\"description\": .string(\"\(description)\")")
-            }
-
-            // Add constraint properties to JSON Schema
-            if let constraint = property.constraint {
-                switch constraint.type {
-                case .range(let min, let max):
-                    schemaComponents.append("\"minimum\": .int(\(min))")
-                    schemaComponents.append("\"maximum\": .int(\(max))")
-                case .rangeDouble(let min, let max):
-                    schemaComponents.append("\"minimum\": .double(\(min))")
-                    schemaComponents.append("\"maximum\": .double(\(max))")
-                case .count(_):
-                    // This will be handled in array processing section
-                    break
-                case .options(let values):
-                    let enumValuesString = values.map { ".string(\"\($0)\")" }.joined(separator: ", ")
-                    schemaComponents.append("\"enum\": .array([\(enumValuesString)])")
-                }
-            }
-
-            let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
-            return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
-        } else if baseType.hasPrefix("[") && baseType.hasSuffix("]") {
-            // Handle array types
-            let elementType = String(baseType.dropFirst().dropLast()) // Remove [ and ]
-            if let jsonSchemaType = swiftTypeToJsonSchemaType(elementType) {
-                var schemaComponents: [String] = ["\"type\": .string(\"array\")"]
-                schemaComponents.append("\"items\": .object([\"type\": .string(\"\(jsonSchemaType)\")])")
-
-                if let description = property.description {
-                    schemaComponents.append("\"description\": .string(\"\(description)\")")
-                }
-
-                // Add array-specific constraints
-                if let constraint = property.constraint {
-                    switch constraint.type {
-                    case .count(let value):
-                        schemaComponents.append("\"minItems\": .int(\(value))")
-                        schemaComponents.append("\"maxItems\": .int(\(value))")
-                    default:
-                        break
-                    }
-                }
-
-                let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
-                return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
-            } else {
-                // Assume nested @Schema type; let the compiler enforce conformance via helper
-                var schemaComponents: [String] = ["\"type\": .string(\"array\")"]
-                schemaComponents.append("\"items\": \(elementType).inputSchema")
-
-                if let description = property.description {
-                    schemaComponents.append("\"description\": .string(\"\(description)\")")
-                }
-
-                let schemaString = schemaComponents.joined(separator: ",\n\(PROPERTY_INDENT)")
-                return "\"\(property.name)\": .object([\n\(PROPERTY_INDENT)\(schemaString)\n\(SCHEMA_INDENT)])"
-            }
-        } else {
-            return "\"\(property.name)\": \(baseType).inputSchema"
-        }
+        let swiftType = SwiftType(from: property.type)
+        let schemaValue = schemaForProperty(type: swiftType, description: property.description, constraint: property.constraint)
+        return "\"\(property.name)\": \(schemaValue)"
     }.joined(separator: ",\n\(SCHEMA_INDENT)")
+}
+
+// Generate the schema value for a property (right-hand side of the "name": ... pair)
+private func schemaForProperty(type: SwiftType, description: String?, constraint: FieldConstraintInfo?) -> String {
+    switch type {
+    case .optional(let wrapped):
+        // Optionality is handled by the "required" array; schema is of the wrapped type
+        return schemaForProperty(type: wrapped, description: description, constraint: constraint)
+    case .basic(let basicType):
+        var components: [String] = ["\"type\": .string(\"\(basicType.jsonSchemaType)\")"]
+        if let description = description {
+            components.append("\"description\": .string(\"\(description)\")")
+        }
+        if let constraint = constraint {
+            switch constraint.type {
+            case .range(let min, let max):
+                components.append("\"minimum\": .int(\(min))")
+                components.append("\"maximum\": .int(\(max))")
+            case .rangeDouble(let min, let max):
+                components.append("\"minimum\": .double(\(min))")
+                components.append("\"maximum\": .double(\(max))")
+            case .options(let values):
+                let enumValuesString = values.map { ".string(\"\($0)\")" }.joined(separator: ", ")
+                components.append("\"enum\": .array([\(enumValuesString)])")
+            case .count:
+                // count applies to arrays; ignore here
+                break
+            }
+        }
+        let body = components.joined(separator: ",\n\(PROPERTY_INDENT)")
+        return ".object([\n\(PROPERTY_INDENT)\(body)\n\(SCHEMA_INDENT)])"
+    case .array(let element):
+        var components: [String] = ["\"type\": .string(\"array\")"]
+        let itemSchema = schemaForItems(type: element)
+        components.append("\"items\": \(itemSchema)")
+        if let description = description {
+            components.append("\"description\": .string(\"\(description)\")")
+        }
+        if let constraint = constraint {
+            if case .count(let value) = constraint.type {
+                components.append("\"minItems\": .int(\(value))")
+                components.append("\"maxItems\": .int(\(value))")
+            }
+        }
+        let body = components.joined(separator: ",\n\(PROPERTY_INDENT)")
+        return ".object([\n\(PROPERTY_INDENT)\(body)\n\(SCHEMA_INDENT)])"
+    case .custom(let name):
+        // Delegate to nested schema provider
+        return "\(name).inputSchema"
+    }
+}
+
+// Generate the schema value for array items (a MCP.Value expression)
+private func schemaForItems(type: SwiftType) -> String {
+    switch type {
+    case .optional(let wrapped):
+        return schemaForItems(type: wrapped)
+    case .basic(let basicType):
+        return ".object([\"type\": .string(\"\(basicType.jsonSchemaType)\")])"
+    case .array(let nested):
+        let nestedItems = schemaForItems(type: nested)
+        return ".object([\"type\": .string(\"array\"), \"items\": \(nestedItems)])"
+    case .custom(let name):
+        return "\(name).inputSchema"
+    }
 }
 
 private func generateRequiredFields(from properties: [SchemaFieldInfo]) -> String {

--- a/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
+++ b/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
@@ -1,0 +1,7 @@
+// Re-export the macro definition and related utilities
+@_exported import MCP
+
+// MARK: - SchemaProviding Protocol
+public protocol SchemaProviding {
+    static var inputSchema: MCP.Value { get }
+}

--- a/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
+++ b/Sources/MCPToolMacrosPlugin/MCPToolMacrosPlugin.swift
@@ -1,7 +1,0 @@
-// Re-export the macro definition and related utilities
-@_exported import MCP
-
-// MARK: - SchemaProviding Protocol
-public protocol SchemaProviding {
-    static var inputSchema: MCP.Value { get }
-}

--- a/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
+++ b/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
@@ -9,7 +9,7 @@ import Foundation
 /// ```swift
 /// @Schema
 /// struct FormatTemplateInput {
-///     @Field(description: "The type of format template", validOptions: ["commit", "pr-title"])
+///     @Field(description: "The type of format template", constraint: .options(["commit", "pr-title"]))
 ///     let formatType: String
 /// }
 /// ```

--- a/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
+++ b/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A macro that generates input schema for a Swift struct.
+/// 
+/// This macro generates a static `inputSchema` property containing the JSON schema
+/// definition for the struct, suitable for use in MCP tool definitions.
+///
+/// Usage:
+/// ```swift
+/// @Schema
+/// struct FormatTemplateInput {
+///     @Field(description: "The type of format template", validOptions: ["commit", "pr-title"])
+///     let formatType: String
+/// }
+/// ```
+@attached(extension, conformances: MCP.MCPParameterParsable, names: named(inputSchema), named(parseArguments), named(_requireSchema))
+public macro Schema() = #externalMacro(
+    module: "MCPToolMacros",
+    type: "SchemaMacro"
+)
+
+/// A macro that adds schema information to struct properties.
+/// 
+/// This macro is used in conjunction with @Schema to provide metadata
+/// for JSON schema generation. Similar to Foundation's @Guide macro.
+///
+/// Usage:
+/// ```swift
+/// @Field(description: "The temperature units", constraint: .options(["celsius", "fahrenheit"]))
+/// var units: String
+/// 
+/// @Field(description: "User age", constraint: .range(0...120))
+/// var age: Int
+/// 
+/// @Field(description: "Search terms", constraint: .count(5))
+/// var searchTerms: [String]
+/// 
+/// @Field(description: "Price", constraint: .rangeDouble(0.0...999.9))
+/// var price: Double
+/// ```
+@attached(peer)
+public macro Field(
+    description: String? = nil,
+    constraint: FieldConstraint? = nil,
+    isRequired: Bool? = nil
+) = #externalMacro(
+    module: "MCPToolMacros",
+    type: "FieldMacro"
+)
+
+
+/// Field constraints similar to Foundation's @Guide macro  
+/// Focused on the most essential constraints: enum, range, and count
+public enum FieldConstraint {
+    /// Specifies a numeric range for Int fields
+    case range(ClosedRange<Int>)
+    /// Specifies a numeric range for Double fields  
+    case rangeDouble(ClosedRange<Double>)
+    /// Specifies exact count for arrays
+    case count(Int)
+    /// Specifies allowed enum values - LLM can only choose from these options
+    case options([String])
+}
+
+

--- a/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
+++ b/Sources/MCPToolMacrosPlugin/ToolRegistration.swift
@@ -1,3 +1,4 @@
+import MCP
 import Foundation
 
 /// A macro that generates input schema for a Swift struct.
@@ -32,11 +33,8 @@ public macro Schema() = #externalMacro(
 /// @Field(description: "User age", constraint: .range(0...120))
 /// var age: Int
 /// 
-/// @Field(description: "Search terms", constraint: .count(5))
+/// @Field(description: "Search terms")
 /// var searchTerms: [String]
-/// 
-/// @Field(description: "Price", constraint: .rangeDouble(0.0...999.9))
-/// var price: Double
 /// ```
 @attached(peer)
 public macro Field(
@@ -50,14 +48,10 @@ public macro Field(
 
 
 /// Field constraints similar to Foundation's @Guide macro  
-/// Focused on the most essential constraints: enum, range, and count
+/// Focused on the most essential constraints: enum and range
 public enum FieldConstraint {
     /// Specifies a numeric range for Int fields
     case range(ClosedRange<Int>)
-    /// Specifies a numeric range for Double fields  
-    case rangeDouble(ClosedRange<Double>)
-    /// Specifies exact count for arrays
-    case count(Int)
     /// Specifies allowed enum values - LLM can only choose from these options
     case options([String])
 }

--- a/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
+++ b/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
@@ -179,4 +179,5 @@ extension User: MCP.MCPParameterParsable {
             ]
         )
     }
+    
 }

--- a/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
+++ b/Tests/MCPToolMacrosTests/ToolRegistrationMacroTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+import SwiftSyntaxMacrosTestSupport
+
+@testable import MCPToolMacros
+
+final class SchemaMacroTests: XCTestCase {
+    
+    func testSchemaMacroWithField() throws {
+        assertMacroExpansion(
+            """
+            @Schema
+            struct UserPreferences {
+                @Field(description: "User's preferred theme", constraint: .options(["light", "dark"]))
+                let theme: String
+                
+                @Field(description: "Enable notifications")
+                let notifications: Bool
+            }
+            """,
+            expandedSource: """
+struct UserPreferences {
+    let theme: String
+    
+    let notifications: Bool
+}
+
+extension UserPreferences: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "theme": .object(["type": .string("string"), "description": .string("User's preferred theme"), "enum": .array([.string("light"), .string("dark")])]),
+                            "notifications": .object(["type": .string("boolean"), "description": .string("Enable notifications")])
+            ]),
+                    "required": .array([.string("theme"), .string("notifications")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> UserPreferences? {
+        guard
+            let parsedTheme = String(args["theme"] ?? .null),
+                    let parsedNotifications = Bool(args["notifications"] ?? .null)
+        else {
+            return nil
+        }
+
+        return UserPreferences(theme: parsedTheme, notifications: parsedNotifications)
+    }
+}
+""",
+            macros: [
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
+            ]
+        )
+    }
+    
+    func testSchemaMacroWithOptionalField() throws {
+        assertMacroExpansion(
+            """
+            @Schema
+            struct UserProfile {
+                @Field(description: "User name")
+                let name: String
+                
+                @Field(description: "User email")
+                let email: String?
+            }
+            """,
+            expandedSource: """
+struct UserProfile {
+    let name: String
+    
+    let email: String?
+}
+
+extension UserProfile: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "name": .object(["type": .string("string"), "description": .string("User name")]),
+                            "email": .object(["type": .string("string"), "description": .string("User email")])
+            ]),
+                    "required": .array([.string("name")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> UserProfile? {
+        guard
+            let parsedName = String(args["name"] ?? .null),
+                    let parsedEmail = String(args["email"] ?? .null)
+        else {
+            return nil
+        }
+
+        return UserProfile(name: parsedName, email: parsedEmail)
+    }
+}
+""",
+            macros: [
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
+            ]
+        )
+    }
+
+    func testSchemaMacroWithNestedSchema() throws {
+        assertMacroExpansion(
+            """
+            @Schema
+            struct Address {
+                @Field(description: "Street")
+                let street: String
+            }
+
+            @Schema
+            struct User {
+                @Field(description: "User address")
+                let address: Address
+            }
+            """,
+            expandedSource: """
+struct Address {
+    let street: String
+}
+
+extension Address: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "street": .object(["type": .string("string"), "description": .string("Street")])
+            ]),
+                    "required": .array([.string("street")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> Address? {
+        guard
+            let parsedStreet = String(args["street"] ?? .null)
+        else {
+            return nil
+        }
+
+        return Address(street: parsedStreet)
+    }
+}
+
+struct User {
+    let address: Address
+}
+
+extension User: MCP.MCPParameterParsable {
+    public static var inputSchema: MCP.Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                            "address": Address.inputSchema
+            ]),
+                    "required": .array([.string("address")])
+        ])
+    }
+
+    public static func parseArguments(_ args: [String: MCP.Value]) -> User? {
+        guard
+            let parsedAddress = Address.parseArguments(args["address"]?.objectValue ?? Dictionary<String, MCP.Value>())
+        else {
+            return nil
+        }
+
+        return User(address: parsedAddress)
+    }
+}
+""",
+            macros: [
+                "Schema": SchemaMacro.self,
+                "Field": FieldMacro.self
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces Swift macros to declare MCP tool input models and generate both the JSON Schema and type-safe argument parsing at build time.

- `@Schema`: Generates `inputSchema` and `parseArguments(_:)`, and makes the type conform to `MCPParameterParsable`.
- `@Field`: Adds field-level metadata (description and constraints like `options`, `range`, `rangeDouble`, `count`).
- `CallTool.Parameters.parseAs<T>`: A convenience API to parse tool parameters into a strongly typed struct.

## Key Changes
- New macro targets and plugin setup:
  - Target: `MCPToolMacros` (macro).
  - Target: `MCPToolMacrosPlugin` (library), registers macros for the compiler.
  - Tests: `MCPToolMacrosTests` with coverage for basic fields, optionals, nested structs.
- Protocol and API in `Sources/MCP/Server/Tools.swift`:
  - `public protocol MCPParameterParsable`.
  - `CallTool.Parameters.parseAs<T>(_:)` to decode arguments into `T`.
- Dependencies:
  - Add `swift-syntax` for macros.
  - Update `eventsource` to `mattt/eventsource` v1.1.1.

## Motivation
- Make tool input definitions declarative and less error-prone.
- Provide an auto-generated JSON Schema for validation and better editor support.
- Offer type-safe parsing via `parseAs<T>` to avoid manual key lookup errors.

## Usage Example
```swift
@Schema
struct FormatTemplateInput {
    @Field(description: "Format type", constraint: .options(["commit", "pr-title"]))
    let formatType: String
}

// In a tool handler:
if let input = params.parseAs(FormatTemplateInput.self) {
    // use input.formatType
} else {
    // return a parameter error
}
```

## Compatibility
- Requires a toolchain with macro support (Xcode 16.x / Swift 6.0).
- `Package.swift` currently declares `swift-syntax` as `from: "509.0.0"` while `Package.resolved` pins `509.1.1`. Please align these in a follow-up to avoid toolchain drift.

## Notes / Review Highlights
- Optional fields: ensure generated parsing keeps optional properties truly optional at runtime. Current test expansions make optionals required; this will be adjusted in the macro code.
- Naming: consider renaming the compiler plugin type to `MCPToolMacrosCompilerPlugin` to avoid confusion with the library product name.
- Consider adding a `.macro` product for `MCPToolMacros` so external packages can depend on the macro product directly.

## Follow-ups (as separate PRs)
- Improve diagnostics (unsupported types / invalid constraints) via `SwiftDiagnostics`.
- Consider making `parseArguments` / `parseAs` throwing (or return a Result) for better error reporting.
- Align `swift-syntax` version across manifest and lockfile, and document CI toolchain.
- Explore `$defs`/`$ref` in schema generation for large nested models.

## Breaking Changes
- None. This adds new functionality without changing existing public APIs.